### PR TITLE
fix : tsconfig.app.json에서 컴파일 옵션 변경

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -17,8 +17,8 @@
 
     /* Linting */
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,


### PR DESCRIPTION
## #️⃣연관된 이슈

#13 

## 📝작업 내용

✅ 실패 원인 요약
빌드 로그의 핵심 에러는 아래와 같은 TypeScript 컴파일 에러입니다:

TS6133: '[변수명]' is declared but its value is never read.
즉, 선언했지만 사용하지 않은 변수나 import가 너무 많아서 tsc -b 명령이 실패한 것입니다.

🔍 상세 분석
npm run build의 내용은:
"build": "tsc -b && vite build"
즉, 먼저 tsc -b로 타입스크립트 빌드를 수행한 후, vite build를 실행합니다.
그런데 tsc -b 단계에서 에러가 발생하여 빌드 전체가 중단됩니다.

이 에러는 TypeScript 설정 (tsconfig.json) 에서 noUnusedLocals 또는 noUnusedParameters 옵션이 true로 되어 있을 때 발생합니다.

🛠 해결 방법
방법 1. tsconfig.json 수정 (추천)
tsconfig.json 또는 tsconfig.app.json 파일에서 아래 설정을 비활성화하세요:
```
{
  "compilerOptions": {
    "noUnusedLocals": false,
    "noUnusedParameters": false
  }
}
```
이렇게 하면 사용되지 않은 import나 변수는 경고로 남기고 빌드가 실패하지 않게 됩니다.

단점: 코드 정리는 안되지만 배포는 성공함.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
