### PR TITLE
Feat/schedule creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@fullcalendar/react": "^6.1.18",
         "@fullcalendar/timegrid": "^6.1.18",
         "@react-oauth/google": "^0.12.2",
-        "@rollup/rollup-linux-x64-gnu": "*",
         "@types/node": "^24.0.7",
         "date-fns": "^4.1.0",
         "devextreme": "24.2.8",
@@ -2705,12 +2704,12 @@
       "license": "ISC"
     },
     "node_modules/framer-motion": {
-      "version": "12.23.6",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.6.tgz",
-      "integrity": "sha512-dsJ389QImVE3lQvM8Mnk99/j8tiZDM/7706PCqvkQ8sSCnpmWxsgX+g0lj7r5OBVL0U36pIecCTBoIWcM2RuKw==",
+      "version": "12.23.9",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.9.tgz",
+      "integrity": "sha512-TqEHXj8LWfQSKqfdr5Y4mYltYLw96deu6/K9kGDd+ysqRJPNwF9nb5mZcrLmybHbU7gcJ+HQar41U3UTGanbbQ==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.23.6",
+        "motion-dom": "^12.23.9",
         "motion-utils": "^12.23.6",
         "tslib": "^2.4.0"
       },
@@ -2729,6 +2728,8 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3307,9 +3308,9 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.23.6",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.6.tgz",
-      "integrity": "sha512-G2w6Nw7ZOVSzcQmsdLc0doMe64O/Sbuc2bVAbgMz6oP/6/pRStKRiVRV4bQfHp5AHYAKEGhEdVHTM+R3FDgi5w==",
+      "version": "12.23.9",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.9.tgz",
+      "integrity": "sha512-6Sv++iWS8XMFCgU1qwKj9l4xuC47Hp4+2jvPfyTXkqDg2tTzSgX6nWKD4kNFXk0k7llO59LZTPuJigza4A2K1A==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.23.6"
@@ -3932,14 +3933,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rrule": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
-      "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.44.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.1.tgz",
@@ -3953,6 +3946,15 @@
       "os": [
         "linux"
       ]
+    },
+    "node_modules/rrule": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
+      "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react-mobile-picker": "^1.1.2",
         "react-router-dom": "^7.6.3",
         "sort-by": "^0.0.2",
+        "swiper": "^11.2.10",
         "zustand": "^5.0.6"
       },
       "devDependencies": {
@@ -4126,6 +4127,25 @@
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/swiper": {
+      "version": "11.2.10",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.10.tgz",
+      "integrity": "sha512-RMeVUUjTQH+6N3ckimK93oxz6Sn5la4aDlgPzB+rBrG/smPdCTicXyhxa+woIpopz+jewEloiEE3lKo1h9w2YQ==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.7.0"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-mobile-picker": "^1.1.2",
     "react-router-dom": "^7.6.3",
     "sort-by": "^0.0.2",
+    "swiper": "^11.2.10",
     "zustand": "^5.0.6"
   },
   "devDependencies": {

--- a/src/assets/rightChevron.svg
+++ b/src/assets/rightChevron.svg
@@ -1,0 +1,3 @@
+<svg width="9" height="15" viewBox="0 0 9 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.51465 1.47642L7.55292 7.5147L1.51465 13.553" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/BottomNav/NavModal.tsx
+++ b/src/components/BottomNav/NavModal.tsx
@@ -1,10 +1,14 @@
+import { useNavigate } from "react-router-dom";
 import styles from "./NavModal.module.scss";
 
 const NavModal = () => {
+  const navigate = useNavigate();
+
   const modalMenu = [
     {
       id: 0,
       label: "미팅 생성",
+      clickRoute: "/meeting-creation",
     },
     {
       id: 1,
@@ -14,7 +18,11 @@ const NavModal = () => {
   return (
     <div className={styles.navModal}>
       {modalMenu.map((item, _) => (
-        <div key={item.id} className={styles.navModal__row}>
+        <div
+          key={item.id}
+          className={styles.navModal__row}
+          onClick={() => navigate(item.clickRoute)}
+        >
           {item.label}
         </div>
       ))}

--- a/src/components/TimePicker/TimePicker.module.scss
+++ b/src/components/TimePicker/TimePicker.module.scss
@@ -21,7 +21,7 @@ $border-color: #ddd;
   // 중앙 가이드 라인
   .indicator {
     position: absolute;
-    top: calc(50% - #{$item-height / 2});
+    top: calc(50% - calc($item-height / 2));
     left: 0;
     right: 0;
     height: $item-height;

--- a/src/pages/schedule/SchedulePage.tsx
+++ b/src/pages/schedule/SchedulePage.tsx
@@ -11,7 +11,6 @@ const SchedulePage = () => {
   const navigate = useNavigate();
   const userId = "11";
   const { response: schedules, loading, error } = useAPIs(`/schedules?userid=${userId}`);
-  // console.log(schedules);
   return (
     <div className={styles.schedulePage}>
       <div className={styles.schedulePage__viewBox}>

--- a/src/pages/schedule/monthly_schedule/Calendar.scss
+++ b/src/pages/schedule/monthly_schedule/Calendar.scss
@@ -101,7 +101,7 @@
 }
 
 .monthlyScheduleView .react-calendar__month-view__days__day {
-  height: 100px;
+  height: 80px;
 }
 
 .monthlyScheduleView .react-calendar__month-view__days__day--neighboringMonth,

--- a/src/pages/schedule/monthly_schedule/MonthlyScheduleView.tsx
+++ b/src/pages/schedule/monthly_schedule/MonthlyScheduleView.tsx
@@ -15,7 +15,7 @@ const MonthlyScheduleView = ({ schedules }: Props) => {
           const eventName = new Array();
 
           schedules &&
-            schedules.map((user) => {
+            schedules?.map((user) => {
               if (user.date === dateFormatter(date)) {
                 eventName.push(user.scheduleName);
               }

--- a/src/pages/schedule/schedule_creation/ScheduleCreationCard.module.scss
+++ b/src/pages/schedule/schedule_creation/ScheduleCreationCard.module.scss
@@ -1,0 +1,30 @@
+.scheduleCreationCard {
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  border-radius: 8px;
+  border: 1px solid $color-gray-8;
+
+  padding: 20px 16px;
+
+  &__basic {
+    width: 100%;
+
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: start;
+    gap: 16px;
+
+    &__icon {
+      color: $color-orange-2;
+    }
+  }
+}
+
+.active {
+  border: 1px solid $color-orange-5;
+}

--- a/src/pages/schedule/schedule_creation/ScheduleCreationCard.tsx
+++ b/src/pages/schedule/schedule_creation/ScheduleCreationCard.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from "react";
+import styles from "./ScheduleCreationCard.module.scss";
+
+interface Props {
+  icon: React.ReactNode;
+  expand: boolean;
+  data: string;
+  dataSetter: React.Dispatch<React.SetStateAction<string>>;
+  BasicComponent: React.ComponentType<any>;
+  basicProps?: Record<string, any>;
+  ExpandedComponent?: React.ComponentType<{ onChange: (val: string) => void }>;
+}
+
+const ScheduleCreationCard = ({
+  icon,
+  data,
+  dataSetter,
+  expand,
+  BasicComponent,
+  basicProps,
+  ExpandedComponent,
+}: Props) => {
+  const [expandCard, setExpandCard] = useState<boolean>(false);
+  const [sharingData, setSharingData] = useState<string>(); // basic과 expand와의 공유데이터
+  return (
+    <div
+      className={
+        expand && expandCard
+          ? `${styles.active} ${styles.scheduleCreationCard}`
+          : styles.scheduleCreationCard
+      }
+      onClick={() => setExpandCard((prev) => !prev)}
+    >
+      <div className={styles.scheduleCreationCard__basic}>
+        <div className={styles.scheduleCreationCard__basic__icon}>{icon}</div>
+        <div className={styles.scheduleCreationCard__basic__data}>
+          <BasicComponent {...basicProps} sharingData={sharingData} />
+        </div>
+      </div>
+      {expand && expandCard && (
+        <div className={styles.scheduleCreationCard__expanded}>
+          <ExpandedComponent onChange={(item) => setSharingData(item)} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ScheduleCreationCard;

--- a/src/pages/schedule/schedule_creation/ScheduleCreationPage.module.scss
+++ b/src/pages/schedule/schedule_creation/ScheduleCreationPage.module.scss
@@ -1,0 +1,19 @@
+.scheduleCreationPage {
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+
+  padding: 27px 16px;
+}
+
+.active {
+  background-color: $color-orange-5;
+}
+
+.inactive {
+  background-color: $color-orange-6;
+}

--- a/src/pages/schedule/schedule_creation/ScheduleCreationPage.module.scss
+++ b/src/pages/schedule/schedule_creation/ScheduleCreationPage.module.scss
@@ -8,6 +8,13 @@
   justify-content: space-between;
 
   padding: 27px 16px;
+
+  &__buttonContainer {
+    position: relative;
+    width: 100%;
+
+    font-family: Pretendard;
+  }
 }
 
 .active {
@@ -16,4 +23,17 @@
 
 .inactive {
   background-color: $color-orange-6;
+}
+
+.deleteButton {
+  position: absolute;
+  bottom: 66px;
+  left: 50%;
+  transform: translateX(-50%);
+
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 400;
+
+  color: $color-orange-5;
 }

--- a/src/pages/schedule/schedule_creation/ScheduleCreationPage.tsx
+++ b/src/pages/schedule/schedule_creation/ScheduleCreationPage.tsx
@@ -6,11 +6,12 @@ import { apiCall } from "@/utils/apiCall";
 
 interface Props {
   clickedSpan: string;
+  createMode: boolean; // true -> create mode, false -> edit mode
 }
 
 const PATH = `/schedule-create`;
 
-const ScheduleCreationPage = ({ clickedSpan }: Props) => {
+const ScheduleCreationPage = ({ clickedSpan, createMode }: Props) => {
   const [allDataReserved, setAllDataReserved] = useState<boolean>(false);
   const [scheduleTitle, setScheduleTitle] = useState<string>();
   const [scheduleTime, setScheduleTime] = useState<string>();

--- a/src/pages/schedule/schedule_creation/ScheduleCreationPage.tsx
+++ b/src/pages/schedule/schedule_creation/ScheduleCreationPage.tsx
@@ -1,0 +1,64 @@
+import Button from "@/components/Button";
+import React, { useEffect, useState } from "react";
+import styles from "./ScheduleCreationPage.module.scss";
+import ScheduleCreationView from "./ScheduleCreationView";
+import { apiCall } from "@/utils/apiCall";
+
+interface Props {
+  clickedSpan: string;
+}
+
+const PATH = `/schedule-create`;
+
+const ScheduleCreationPage = ({ clickedSpan }: Props) => {
+  const [allDataReserved, setAllDataReserved] = useState<boolean>(false);
+  const [scheduleTitle, setScheduleTitle] = useState<string>();
+  const [scheduleTime, setScheduleTime] = useState<string>();
+  const [repetition, setRepetition] = useState<string>();
+
+  useEffect(() => {
+    console.log("1: ", scheduleTitle);
+    console.log("2: ", scheduleTime);
+    console.log("3: ", repetition);
+    if (scheduleTitle && scheduleTime && repetition) setAllDataReserved(true);
+  }, [scheduleTitle, scheduleTime, repetition]);
+
+  const sendCreationReq = async () => {
+    if (!allDataReserved) return;
+    const data = {
+      scheduleTitle: scheduleTitle,
+      scheduleTime: scheduleTime,
+      repetition: repetition,
+    };
+    const response = await apiCall(PATH, "POST", data, true);
+
+    switch (response.code) {
+      case 20000:
+        alert("일정 생성이 완료되었습니다");
+        break;
+      default:
+        alert("오류가 발생하였습니다.. 잠시후 다시 시도해주세요");
+    }
+  };
+
+  return (
+    <div className={styles.scheduleCreationPage}>
+      <ScheduleCreationView
+        clickedSpan={clickedSpan}
+        scheduleTitle={scheduleTitle}
+        scheduleTime={scheduleTime}
+        repetition={repetition}
+        setScheduleTitle={setScheduleTitle}
+        setScheduleTime={setScheduleTime}
+        setRepetition={setRepetition}
+      />
+      <Button
+        className={allDataReserved ? styles.active : styles.inactive}
+        label={"미팅 생성하기"}
+        clickHandler={sendCreationReq}
+      />
+    </div>
+  );
+};
+
+export default ScheduleCreationPage;

--- a/src/pages/schedule/schedule_creation/ScheduleCreationPage.tsx
+++ b/src/pages/schedule/schedule_creation/ScheduleCreationPage.tsx
@@ -1,21 +1,36 @@
 import Button from "@/components/Button";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import styles from "./ScheduleCreationPage.module.scss";
 import ScheduleCreationView from "./ScheduleCreationView";
 import { apiCall } from "@/utils/apiCall";
+import type { ScheduleDataType } from "@/types/schedule-data-type";
+import { scheduleStringFormatter } from "@/utils/dateFormatter";
 
 interface Props {
   clickedSpan: string;
   createMode: boolean; // true -> create mode, false -> edit mode
+  data?: ScheduleDataType;
 }
 
-const PATH = `/schedule-create`;
+const eventId = 3;
+const CREATE_PATH = `/schedule-create`;
+const EDIT_PATH = `/user/schedule/update`;
+const DEL_PATH = `/user/schedule/delete?eventId=${eventId}`;
 
-const ScheduleCreationPage = ({ clickedSpan, createMode }: Props) => {
+const ScheduleCreationPage = ({ clickedSpan, createMode, data }: Props) => {
   const [allDataReserved, setAllDataReserved] = useState<boolean>(false);
-  const [scheduleTitle, setScheduleTitle] = useState<string>();
+  const [scheduleTitle, setScheduleTitle] = useState<string>("");
   const [scheduleTime, setScheduleTime] = useState<string>();
   const [repetition, setRepetition] = useState<string>();
+
+  useEffect(() => {
+    if (!createMode && data) {
+      setScheduleTitle(data?.title);
+      setScheduleTime(
+        `${scheduleStringFormatter(data?.startAt)} ${scheduleStringFormatter(data?.endAt)}`
+      );
+    }
+  }, []);
 
   useEffect(() => {
     console.log("1: ", scheduleTitle);
@@ -31,11 +46,53 @@ const ScheduleCreationPage = ({ clickedSpan, createMode }: Props) => {
       scheduleTime: scheduleTime,
       repetition: repetition,
     };
-    const response = await apiCall(PATH, "POST", data, true);
+    const response = await apiCall(CREATE_PATH, "POST", data, true);
 
     switch (response.code) {
-      case 20000:
+      case 201:
         alert("일정 생성이 완료되었습니다");
+        break;
+      default:
+        alert("오류가 발생하였습니다.. 잠시후 다시 시도해주세요");
+    }
+  };
+
+  const sendEditReq = async () => {
+    if (!allDataReserved) return;
+    const data = {
+      scheduleTitle: scheduleTitle,
+      scheduleTime: scheduleTime,
+      repetition: repetition,
+    };
+    const response = await apiCall(EDIT_PATH, "PUT", data, true);
+
+    switch (response.code) {
+      case 200:
+        alert("일정을 수정하였습니다!");
+        break;
+      case 401:
+        alert("로그인이 필요합니다!");
+        break;
+      case 404:
+        alert("사용자를 찾을 수 없습니다");
+        break;
+      default:
+        alert("오류가 발생하였습니다.. 잠시후 다시 시도해주세요");
+    }
+  };
+
+  const sendDelReq = async () => {
+    const response = await apiCall(DEL_PATH, "DELETE", null, true);
+
+    switch (response.code) {
+      case 200:
+        alert("일정을 삭제하였습니다!");
+        break;
+      case 401:
+        alert("로그인이 필요합니다!");
+        break;
+      case 404:
+        alert("사용자를 찾을 수 없습니다");
         break;
       default:
         alert("오류가 발생하였습니다.. 잠시후 다시 시도해주세요");
@@ -53,11 +110,18 @@ const ScheduleCreationPage = ({ clickedSpan, createMode }: Props) => {
         setScheduleTime={setScheduleTime}
         setRepetition={setRepetition}
       />
-      <Button
-        className={allDataReserved ? styles.active : styles.inactive}
-        label={"미팅 생성하기"}
-        clickHandler={sendCreationReq}
-      />
+      <div className={styles.scheduleCreationPage__buttonContainer}>
+        {!createMode && (
+          <div className={styles.deleteButton} onClick={sendDelReq}>
+            삭제하기
+          </div>
+        )}
+        <Button
+          className={allDataReserved ? styles.active : styles.inactive}
+          label={createMode ? "미팅 생성하기" : "완료"}
+          clickHandler={createMode ? sendCreationReq : sendEditReq}
+        />
+      </div>
     </div>
   );
 };

--- a/src/pages/schedule/schedule_creation/ScheduleCreationView.module.scss
+++ b/src/pages/schedule/schedule_creation/ScheduleCreationView.module.scss
@@ -1,0 +1,33 @@
+.scheduleCreationView {
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: start;
+  gap: 24px;
+
+  &__inputTag {
+    width: 100%;
+    height: 2.5rem;
+
+    padding: 0 5px;
+
+    font-size: 21px;
+    font-style: normal;
+    font-weight: 700;
+
+    border: none;
+    border-bottom: 1px solid $color-gray-8;
+  }
+
+  &__scheduleOptionContainer {
+    width: 100%;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: start;
+    gap: 12px;
+  }
+}

--- a/src/pages/schedule/schedule_creation/ScheduleCreationView.tsx
+++ b/src/pages/schedule/schedule_creation/ScheduleCreationView.tsx
@@ -56,12 +56,17 @@ const ScheduleCreationView = ({
     },
   ];
 
+  useEffect(() => {
+    console.log(scheduleTitle);
+  }, [scheduleTitle]);
+
   return (
     <div className={styles.scheduleCreationView}>
       <input
         className={styles.scheduleCreationView__inputTag}
         type="text"
         placeholder="일정 제목"
+        value={scheduleTitle}
         onChange={(e) => {
           setScheduleTitle(e.target.value);
         }}

--- a/src/pages/schedule/schedule_creation/ScheduleCreationView.tsx
+++ b/src/pages/schedule/schedule_creation/ScheduleCreationView.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from "react";
+import styles from "./ScheduleCreationView.module.scss";
+import Button from "@/components/Button";
+import Clock from "@assets/clock.svg?react";
+import Pencil from "@assets/pencil.svg?react";
+import TimePicker from "@/components/TimePicker/TimePicker";
+import ScheduleCreationCard from "./ScheduleCreationCard";
+import ScheduleRepetitionRow from "./ScheduleRepetitionRow";
+import ScheduleDurationRow from "./ScheduleDurationRow";
+
+interface Props {
+  clickedSpan: string;
+  scheduleTitle: string;
+  scheduleTime: string;
+  repetition: string;
+  setScheduleTitle: React.Dispatch<React.SetStateAction<string>>;
+  setScheduleTime: React.Dispatch<React.SetStateAction<string>>;
+  setRepetition: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const ScheduleCreationView = ({
+  clickedSpan,
+  scheduleTitle,
+  scheduleTime,
+  repetition,
+  setScheduleTitle,
+  setScheduleTime,
+  setRepetition,
+}: Props) => {
+  const cardDataSet = [
+    {
+      id: 0,
+      icon: <Clock />,
+      expand: true,
+      expandComponent: TimePicker,
+      basicComponent: ScheduleDurationRow,
+      basicProps: {
+        clickedSpan,
+        dataSetter: setScheduleTime,
+      },
+      data: scheduleTime,
+      dataSetter: setScheduleTime,
+    },
+    {
+      id: 1,
+      icon: <Pencil />,
+      expand: false,
+      expandedComponent: null,
+      basicComponent: ScheduleRepetitionRow,
+      basicProps: {
+        data: repetition,
+        dataSetter: setRepetition,
+      },
+      data: repetition,
+      dataSetter: setRepetition,
+    },
+  ];
+
+  return (
+    <div className={styles.scheduleCreationView}>
+      <input
+        className={styles.scheduleCreationView__inputTag}
+        type="text"
+        placeholder="일정 제목"
+        onChange={(e) => {
+          setScheduleTitle(e.target.value);
+        }}
+      />
+      <div className={styles.scheduleCreationView__scheduleOptionContainer}>
+        {cardDataSet.map((item, _) => (
+          <ScheduleCreationCard
+            key={item.id}
+            icon={item.icon}
+            expand={item.expand}
+            data={item.data}
+            dataSetter={item.dataSetter}
+            BasicComponent={item.basicComponent}
+            basicProps={item.basicProps}
+            ExpandedComponent={item.expandComponent}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ScheduleCreationView;

--- a/src/pages/schedule/schedule_creation/ScheduleDurationRow.module.scss
+++ b/src/pages/schedule/schedule_creation/ScheduleDurationRow.module.scss
@@ -1,0 +1,13 @@
+.scheduleDurationRow {
+  width: 100%;
+
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: start;
+  gap: 2rem;
+}
+
+.active {
+  color: $color-orange-5;
+}

--- a/src/pages/schedule/schedule_creation/ScheduleDurationRow.tsx
+++ b/src/pages/schedule/schedule_creation/ScheduleDurationRow.tsx
@@ -1,0 +1,84 @@
+import React, { useEffect, useState } from "react";
+import styles from "./ScheduleDurationRow.module.scss";
+import RightChevron from "@assets/rightChevron.svg?react";
+
+interface Props {
+  clickedSpan: string;
+  sharingData: string;
+  dataSetter: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const ScheduleDurationRow = ({ clickedSpan, sharingData, dataSetter }: Props) => {
+  // ex) clickedSpan : 07월 31일(목) 오전 02:00 07월 31일(목) 오전 05:30
+  const parts = clickedSpan.split(" ");
+
+  const [startOrEnd, setStartOrEnd] = useState<number>(0);
+  const [startTime, setStartTime] = useState<string>("");
+  const [endTime, setEndTime] = useState<string>("");
+
+  useEffect(() => {
+    setStartTime(`${parts[2]} ${parts[3]}`);
+    setEndTime(`${parts[6]} ${parts[7]}`);
+  }, [clickedSpan]);
+
+  useEffect(() => {
+    if (sharingData == null || sharingData === "") return;
+    if (startOrEnd === 1) {
+      setStartTime(sharingData);
+    } else if (startOrEnd === 2) {
+      setEndTime(sharingData);
+    }
+  }, [sharingData, startOrEnd]);
+
+  useEffect(() => {
+    dataSetter(`${parts[0]} ${parts[1]} ${startTime} ${parts[4]} ${parts[5]} ${endTime}`);
+  }, [startTime, endTime]);
+
+  return (
+    <div className={styles.scheduleDurationRow}>
+      <div
+        className={styles.scheduleDurationRow__box}
+        onClick={(e) => {
+          e.stopPropagation();
+          setStartOrEnd(1);
+        }}
+      >
+        <div className={styles.scheduleDurationRow__box__date}>
+          {parts[0]} {parts[1]}
+        </div>
+        <div
+          className={
+            startOrEnd === 1
+              ? `${styles.active} ${styles.scheduleDurationRow__box__time}`
+              : styles.scheduleDurationRow__box__time
+          }
+        >
+          {startTime}
+        </div>
+      </div>
+      <RightChevron />
+      <div
+        className={styles.scheduleDurationRow__box}
+        onClick={(e) => {
+          e.stopPropagation();
+          setStartOrEnd(2);
+        }}
+      >
+        <div className={styles.scheduleDurationRow__box__date}>
+          {parts[4]} {parts[5]}
+        </div>
+        <div
+          className={
+            startOrEnd === 2
+              ? `${styles.active} ${styles.scheduleDurationRow__box__time}`
+              : styles.scheduleDurationRow__box__time
+          }
+        >
+          {endTime}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ScheduleDurationRow;

--- a/src/pages/schedule/schedule_creation/ScheduleRepetitionRow.module.scss
+++ b/src/pages/schedule/schedule_creation/ScheduleRepetitionRow.module.scss
@@ -1,0 +1,21 @@
+.scheduleRepetitionRow {
+  width: 100%;
+
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: start;
+  gap: 1.5rem;
+
+  &__item {
+    font-family: Pretendard;
+    font-size: 17px;
+    font-style: normal;
+    font-weight: 600;
+    color: $color-gray-5;
+  }
+}
+
+.active {
+  color: #343434;
+}

--- a/src/pages/schedule/schedule_creation/ScheduleRepetitionRow.tsx
+++ b/src/pages/schedule/schedule_creation/ScheduleRepetitionRow.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import styles from "./ScheduleRepetitionRow.module.scss";
+
+interface Props {
+  data: string;
+  dataSetter: React.Dispatch<React.SetStateAction<string>>;
+  sharingData?: string;
+}
+
+const ScheduleRepetitionRow = ({ data, dataSetter }: Props) => {
+  const options = [
+    { id: 0, label: "없음" },
+    {
+      id: 1,
+      label: "매일",
+    },
+    {
+      id: 2,
+      label: "매주",
+    },
+    {
+      id: 3,
+      label: "격주",
+    },
+    {
+      id: 4,
+      label: "매달",
+    },
+  ];
+  return (
+    <div className={styles.scheduleRepetitionRow}>
+      {options.map((item, _) => (
+        <div
+          key={item.id}
+          onClick={() => dataSetter(item.label)}
+          className={
+            data === item.label
+              ? `${styles.active} ${styles.scheduleRepetitionRow__item}`
+              : styles.scheduleRepetitionRow__item
+          }
+        >
+          {item.label}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ScheduleRepetitionRow;

--- a/src/pages/schedule/weekly_schedule/CustomEvent.tsx
+++ b/src/pages/schedule/weekly_schedule/CustomEvent.tsx
@@ -1,3 +1,7 @@
 import styles from "./CustomEvent.module.scss";
 
-export const CustomEvent = ({ event }: any) => <div className={styles.customEvent}></div>;
+export const CustomEvent = ({ event }: any) => {
+  console.log(event);
+
+  return <div className={styles.customEvent}>{event.title}</div>;
+};

--- a/src/pages/schedule/weekly_schedule/CustomWeekHeader.module.scss
+++ b/src/pages/schedule/weekly_schedule/CustomWeekHeader.module.scss
@@ -1,0 +1,30 @@
+.customWeekHeader {
+  font-family: Pretendard;
+  &__date {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    height: 1.5rem;
+
+    font-size: 11px;
+    font-style: normal;
+    font-weight: 600;
+    color: $color-gray-2;
+  }
+  &__day {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    font-size: 12px;
+    font-style: normal;
+    font-weight: 400;
+
+    height: 2rem;
+  }
+}
+
+.sunday {
+  color: $color-orange-5 !important;
+}

--- a/src/pages/schedule/weekly_schedule/CustomWeekHeader.tsx
+++ b/src/pages/schedule/weekly_schedule/CustomWeekHeader.tsx
@@ -3,8 +3,16 @@ import styles from "./CustomWeekHeader.module.scss";
 const CustomWeekHeader = ({ label }: any) => {
   return (
     <div className={styles.customWeekHeader}>
-      <div className={styles.customWeekHeader__date}>{label.substr(0, 2)}</div>
-      <div className={styles.customWeekHeader__day}>{label.substr(2)}</div>
+      <div
+        className={
+          label.substr(3) === "Sun"
+            ? `${styles.customWeekHeader__date} ${styles.sunday}`
+            : styles.customWeekHeader__date
+        }
+      >
+        {label.substring(3, 4)}
+      </div>
+      <div className={styles.customWeekHeader__day}>{label.substr(0, 2)}</div>
     </div>
   );
 };

--- a/src/pages/schedule/weekly_schedule/WeeklyCalendar.scss
+++ b/src/pages/schedule/weekly_schedule/WeeklyCalendar.scss
@@ -890,35 +890,39 @@ button.rbc-input::-moz-focus-inner {
   display: none;
 }
 
-// .calendar-container {
-//   position: relative;
-
-//   width: 100%;
-//   height: 100%;
-
-//   overflow-x: hidden;
-// }
-
-// .calendar-slider {
-//   width: 300%;
-//   height: 100%;
-
-//   transform: translateX(-33.333%);
-// }
-
-// .calendar-viewport {
-//   position: absolute;
-
-//   width: 100%;
-//   height: 100%;
-
-//   display: flex;
-//   flex-direction: row;
-// }
-
-// .rbc-calendar {
-//   width: 100%;
-// }
 .swiper {
   width: 100% !important;
+}
+
+.rbc-event-label {
+  display: none;
+}
+
+.slideUpContainer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100vw;
+  height: 70vh; /* 화면 높이의 90% */
+  background-color: #fff;
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.1);
+  overflow-y: auto;
+  z-index: 1000;
+}
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+}
+
+.rbc-calendar,
+.rbc-day-slot,
+.rbc-time-slot,
+.rbc-timeslot-group {
+  touch-action: manipulation !important;
+  pointer-events: manipulation !important;
+  user-select: manipulation !important;
 }

--- a/src/pages/schedule/weekly_schedule/WeeklyCalendar.scss
+++ b/src/pages/schedule/weekly_schedule/WeeklyCalendar.scss
@@ -887,3 +887,33 @@ button.rbc-input::-moz-focus-inner {
 .rbc-allday-cell {
   display: none;
 }
+
+.calendar-container {
+  position: relative;
+
+  width: 100%;
+  height: 100%;
+
+  overflow-x: hidden;
+}
+
+.calendar-slider {
+  width: 300%;
+  height: 100%;
+
+  transform: translateX(-33.333%);
+}
+
+.calendar-viewport {
+  position: absolute;
+
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  flex-direction: row;
+}
+
+.rbc-calendar {
+  width: 100%;
+}

--- a/src/pages/schedule/weekly_schedule/WeeklyCalendar.scss
+++ b/src/pages/schedule/weekly_schedule/WeeklyCalendar.scss
@@ -41,7 +41,6 @@ button.rbc-input::-moz-focus-inner {
   background-color: $color-cream-light;
   width: 100%;
   overflow: scroll;
-  padding-top: 10px;
 }
 
 .rbc-m-b-negative-3 {
@@ -171,9 +170,12 @@ button.rbc-input::-moz-focus-inner {
 }
 
 .rbc-toolbar {
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
+  //
+  // display: -webkit-box;
+  // display: -ms-flexbox;
+  // display: flex;
+  display: none;
+  //
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: center;
@@ -888,32 +890,35 @@ button.rbc-input::-moz-focus-inner {
   display: none;
 }
 
-.calendar-container {
-  position: relative;
+// .calendar-container {
+//   position: relative;
 
-  width: 100%;
-  height: 100%;
+//   width: 100%;
+//   height: 100%;
 
-  overflow-x: hidden;
-}
+//   overflow-x: hidden;
+// }
 
-.calendar-slider {
-  width: 300%;
-  height: 100%;
+// .calendar-slider {
+//   width: 300%;
+//   height: 100%;
 
-  transform: translateX(-33.333%);
-}
+//   transform: translateX(-33.333%);
+// }
 
-.calendar-viewport {
-  position: absolute;
+// .calendar-viewport {
+//   position: absolute;
 
-  width: 100%;
-  height: 100%;
+//   width: 100%;
+//   height: 100%;
 
-  display: flex;
-  flex-direction: row;
-}
+//   display: flex;
+//   flex-direction: row;
+// }
 
-.rbc-calendar {
-  width: 100%;
+// .rbc-calendar {
+//   width: 100%;
+// }
+.swiper {
+  width: 100% !important;
 }

--- a/src/pages/schedule/weekly_schedule/WeeklyCalendar.tsx
+++ b/src/pages/schedule/weekly_schedule/WeeklyCalendar.tsx
@@ -1,0 +1,50 @@
+import { colorAutoSelector } from "@/utils/colorAutoSelector";
+import CustomWeekHeader from "./CustomWeekHeader";
+import { CustomEvent } from "./CustomEvent";
+import { Calendar, luxonLocalizer } from "react-big-calendar";
+import { DateTime } from "luxon";
+
+interface Props {
+  week: Date;
+  events: any[];
+}
+
+const localizer = luxonLocalizer(DateTime);
+
+const formats = {
+  timeGutterFormat: (date: Date, culture: string, localizer: any) => {
+    return DateTime.fromJSDate(date).toFormat("H"); // 예: 22
+  },
+};
+
+const WeeklyCalendar = ({ week, events }: Props) => {
+  return (
+    <Calendar
+      date={week}
+      localizer={localizer}
+      events={events}
+      formats={formats}
+      startAccessor="start"
+      endAccessor="end"
+      defaultView="week"
+      views={["week"]}
+      components={{
+        week: {
+          header: CustomWeekHeader,
+          event: CustomEvent,
+        },
+      }}
+      eventPropGetter={(event) => {
+        return {
+          style: {
+            backgroundColor: `${colorAutoSelector(event.id)}`,
+            borderRadius: "6px",
+            color: "white",
+          },
+        };
+      }}
+    />
+  );
+};
+
+export default WeeklyCalendar;

--- a/src/pages/schedule/weekly_schedule/WeeklyCalendar.tsx
+++ b/src/pages/schedule/weekly_schedule/WeeklyCalendar.tsx
@@ -3,6 +3,12 @@ import CustomWeekHeader from "./CustomWeekHeader";
 import { CustomEvent } from "./CustomEvent";
 import { Calendar, luxonLocalizer } from "react-big-calendar";
 import { DateTime } from "luxon";
+import { useState } from "react";
+import ReactDOM from "react-dom";
+import { AnimatePresence, motion } from "framer-motion";
+import ScheduleCreationPage from "../schedule_creation/ScheduleCreationPage";
+import { format } from "date-fns/format";
+import { ko } from "date-fns/locale";
 
 interface Props {
   week: Date;
@@ -18,32 +24,97 @@ const formats = {
 };
 
 const WeeklyCalendar = ({ week, events }: Props) => {
+  const [creationOpen, setCreationOpen] = useState<boolean>(false);
+  const [clickedSpan, setClickedSpan] = useState<string>();
+
+  const portal = ReactDOM.createPortal(
+    <AnimatePresence>
+      {creationOpen && (
+        <>
+          {/* 1) 백드롭: 클릭 시 닫기 */}
+          <motion.div key="backdrop" className="backdrop" onClick={() => setCreationOpen(false)} />
+
+          {/* 2) 슬라이드업 패널: 클릭 이벤트 전파 차단 */}
+          <motion.div
+            key="panel"
+            className="slideUpContainer"
+            initial={{ y: "100%" }}
+            animate={{ y: 0 }}
+            exit={{ y: "100%" }}
+            transition={{ type: "spring", stiffness: 300, damping: 30 }}
+            onClick={(e) => e.stopPropagation()}
+            drag="y"
+            dragDirectionLock={true}
+            onDragEnd={(_, info) => {
+              console.log(info.offset.y);
+              console.log(window.innerHeight);
+              if (info.offset.y > window.innerHeight * 0.2) {
+                setCreationOpen(false);
+              }
+            }}
+          >
+            <ScheduleCreationPage clickedSpan={clickedSpan} />
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>,
+    document.body
+  );
   return (
-    <Calendar
-      date={week}
-      localizer={localizer}
-      events={events}
-      formats={formats}
-      startAccessor="start"
-      endAccessor="end"
-      defaultView="week"
-      views={["week"]}
-      components={{
-        week: {
-          header: CustomWeekHeader,
-          event: CustomEvent,
-        },
-      }}
-      eventPropGetter={(event) => {
-        return {
-          style: {
-            backgroundColor: `${colorAutoSelector(event.id)}`,
-            borderRadius: "6px",
-            color: "white",
+    <>
+      <Calendar
+        date={week}
+        localizer={localizer}
+        events={events}
+        formats={formats}
+        startAccessor="start"
+        endAccessor="end"
+        defaultView="week"
+        views={["week"]}
+        components={{
+          week: {
+            header: CustomWeekHeader,
+            event: CustomEvent,
           },
-        };
-      }}
-    />
+        }}
+        eventPropGetter={(event) => {
+          return {
+            style: {
+              backgroundColor: `${colorAutoSelector(event.id)}`,
+              borderRadius: "6px",
+              color: "white",
+            },
+          };
+        }}
+        selectable={true}
+        step={30} // ✅ 각 시간 슬롯 간격 (분 단위)
+        timeslots={2} // ✅ 한 시간당 몇 개의 슬롯
+        longPressThreshold={0}
+        onSelectSlot={(slotInfo) => {
+          setTimeout(() => setCreationOpen(true), 0);
+          console.log("빈 영역 클릭됨:", slotInfo);
+          const formattedStartDate = format(slotInfo.start, "MM월 dd일(EEE)", { locale: ko });
+          const formattedStartTime = format(slotInfo.start, "a hh:mm")
+            .replace("AM", "오전")
+            .replace("PM", "오후");
+          const formattedEndDate = format(slotInfo.end, "MM월 dd일(EEE)", { locale: ko });
+          const formattedEndTime = format(slotInfo.end, "a hh:mm")
+            .replace("AM", "오전")
+            .replace("PM", "오후");
+          console.log(
+            `${formattedStartDate} ${formattedStartTime} ${formattedEndDate} ${formattedEndTime}`
+          );
+          setClickedSpan(
+            `${formattedStartDate} ${formattedStartTime} ${formattedEndDate} ${formattedEndTime}`
+          );
+        }}
+        onSelectEvent={(event) => {
+          console.log("일정 클릭됨:", event);
+          // 원하는 동작 수행 (예: 모달 열기, 상세 페이지 이동 등)
+        }}
+      />
+      {portal}
+    </>
   );
 };
 

--- a/src/pages/schedule/weekly_schedule/WeeklyCalendar.tsx
+++ b/src/pages/schedule/weekly_schedule/WeeklyCalendar.tsx
@@ -13,6 +13,7 @@ import { ko } from "date-fns/locale";
 interface Props {
   week: Date;
   events: any[];
+  blockInteraction: boolean;
 }
 
 const localizer = luxonLocalizer(DateTime);
@@ -23,7 +24,7 @@ const formats = {
   },
 };
 
-const WeeklyCalendar = ({ week, events }: Props) => {
+const WeeklyCalendar = ({ week, events, blockInteraction }: Props) => {
   const [creationOpen, setCreationOpen] = useState<boolean>(false);
   const [clickedSpan, setClickedSpan] = useState<string>();
 
@@ -53,7 +54,7 @@ const WeeklyCalendar = ({ week, events }: Props) => {
               }
             }}
           >
-            <ScheduleCreationPage clickedSpan={clickedSpan} />
+            <ScheduleCreationPage clickedSpan={clickedSpan} createMode={true} />
           </motion.div>
         </>
       )}
@@ -89,8 +90,10 @@ const WeeklyCalendar = ({ week, events }: Props) => {
         selectable={true}
         step={30} // ✅ 각 시간 슬롯 간격 (분 단위)
         timeslots={2} // ✅ 한 시간당 몇 개의 슬롯
-        longPressThreshold={0}
+        longPressThreshold={150}
+        onSelecting={() => !blockInteraction}
         onSelectSlot={(slotInfo) => {
+          if (blockInteraction) return;
           setTimeout(() => setCreationOpen(true), 0);
           console.log("빈 영역 클릭됨:", slotInfo);
           const formattedStartDate = format(slotInfo.start, "MM월 dd일(EEE)", { locale: ko });
@@ -109,6 +112,7 @@ const WeeklyCalendar = ({ week, events }: Props) => {
           );
         }}
         onSelectEvent={(event) => {
+          if (blockInteraction) return;
           console.log("일정 클릭됨:", event);
           // 원하는 동작 수행 (예: 모달 열기, 상세 페이지 이동 등)
         }}

--- a/src/pages/schedule/weekly_schedule/WeeklyCalendar.tsx
+++ b/src/pages/schedule/weekly_schedule/WeeklyCalendar.tsx
@@ -50,9 +50,10 @@ const WeeklyCalendar = ({ week, events, blockInteraction }: Props) => {
             onClick={(e) => e.stopPropagation()}
             drag="y"
             dragDirectionLock={true}
+            dragConstraints={{ top: 0, bottom: 1000 }}
+            dragElastic={0}
+            dragMomentum={false}
             onDragEnd={(_, info) => {
-              console.log(info.offset.y);
-              console.log(window.innerHeight);
               if (info.offset.y > window.innerHeight * 0.2) {
                 setCreationOpen(false);
               }

--- a/src/pages/schedule/weekly_schedule/WeeklyCalendar.tsx
+++ b/src/pages/schedule/weekly_schedule/WeeklyCalendar.tsx
@@ -9,6 +9,8 @@ import { AnimatePresence, motion } from "framer-motion";
 import ScheduleCreationPage from "../schedule_creation/ScheduleCreationPage";
 import { format } from "date-fns/format";
 import { ko } from "date-fns/locale";
+import type { ScheduleDataType } from "@/types/schedule-data-type";
+import { scheduleStringFormatter } from "@/utils/dateFormatter";
 
 interface Props {
   week: Date;
@@ -27,6 +29,8 @@ const formats = {
 const WeeklyCalendar = ({ week, events, blockInteraction }: Props) => {
   const [creationOpen, setCreationOpen] = useState<boolean>(false);
   const [clickedSpan, setClickedSpan] = useState<string>();
+  const [clickedSchedule, setClickedSchedule] = useState<ScheduleDataType>();
+  const [mode, setMode] = useState<boolean>(true); // 생성모드 or 수정모드
 
   const portal = ReactDOM.createPortal(
     <AnimatePresence>
@@ -54,7 +58,11 @@ const WeeklyCalendar = ({ week, events, blockInteraction }: Props) => {
               }
             }}
           >
-            <ScheduleCreationPage clickedSpan={clickedSpan} createMode={true} />
+            <ScheduleCreationPage
+              clickedSpan={clickedSpan}
+              createMode={mode}
+              data={clickedSchedule}
+            />
           </motion.div>
         </>
       )}
@@ -96,25 +104,24 @@ const WeeklyCalendar = ({ week, events, blockInteraction }: Props) => {
           if (blockInteraction) return;
           setTimeout(() => setCreationOpen(true), 0);
           console.log("빈 영역 클릭됨:", slotInfo);
-          const formattedStartDate = format(slotInfo.start, "MM월 dd일(EEE)", { locale: ko });
-          const formattedStartTime = format(slotInfo.start, "a hh:mm")
-            .replace("AM", "오전")
-            .replace("PM", "오후");
-          const formattedEndDate = format(slotInfo.end, "MM월 dd일(EEE)", { locale: ko });
-          const formattedEndTime = format(slotInfo.end, "a hh:mm")
-            .replace("AM", "오전")
-            .replace("PM", "오후");
-          console.log(
-            `${formattedStartDate} ${formattedStartTime} ${formattedEndDate} ${formattedEndTime}`
-          );
-          setClickedSpan(
-            `${formattedStartDate} ${formattedStartTime} ${formattedEndDate} ${formattedEndTime}`
-          );
+          const formattedStart = scheduleStringFormatter(slotInfo.start);
+          const formattedEnd = scheduleStringFormatter(slotInfo.end);
+
+          setClickedSpan(`${formattedStart} ${formattedEnd}`);
         }}
         onSelectEvent={(event) => {
           if (blockInteraction) return;
+          setMode(false);
+          setTimeout(() => setCreationOpen(true), 0);
           console.log("일정 클릭됨:", event);
-          // 원하는 동작 수행 (예: 모달 열기, 상세 페이지 이동 등)
+          setClickedSchedule({
+            title: event.title,
+            startAt: event.start,
+            endAt: event.end,
+          });
+          setClickedSpan(
+            `${scheduleStringFormatter(event.start)} ${scheduleStringFormatter(event.end)}`
+          );
         }}
       />
       {portal}

--- a/src/pages/schedule/weekly_schedule/WeeklyScheduleView.tsx
+++ b/src/pages/schedule/weekly_schedule/WeeklyScheduleView.tsx
@@ -6,6 +6,8 @@ import CustomWeekHeader from "./CustomWeekHeader";
 import { colorAutoSelector } from "@/utils/colorAutoSelector";
 import { useRef, useState } from "react";
 import { addWeeks, subWeeks } from "date-fns";
+import { Swiper, SwiperSlide } from "swiper/react";
+import "swiper/swiper-bundle.css";
 
 interface Props {
   schedules: any[];
@@ -27,7 +29,7 @@ const WeeklyScheduleView = ({ schedules }: Props) => {
   const [offset, setOffset] = useState(0); // 슬라이딩용 오프셋
   const touchStartX = useRef<number | null>(null);
 
-  const events = schedules.map((item, index) => ({
+  const events = schedules?.map((item, index) => ({
     id: item.id,
     title: item.scheduleName,
     start: new Date(`${item.date}T${item.startTime}`),
@@ -58,9 +60,11 @@ const WeeklyScheduleView = ({ schedules }: Props) => {
     }
 
     touchStartX.current = null;
+
+    console.log(offset);
   };
 
-  const calendaryArr = [
+  const calendarArr = [
     <Calendar
       date={prevWeek}
       localizer={localizer}
@@ -140,37 +144,49 @@ const WeeklyScheduleView = ({ schedules }: Props) => {
   ];
 
   return (
-    <div className="calendar-container" onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
-      <div className="calendar-slider" style={{ transform: `translateX(${offset}%)` }}>
-        <div className="calendar-viewport">{calendaryArr.map((item, index) => item)}</div>
-      </div>
+    // <div className="calendar-container" onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
+    //   <div className="calendar-slider" style={{ transform: `translateX(${offset}%)` }}>
+    //     <div className="calendar-viewport">{calendaryArr.map((item, index) => item)}</div>
+    //   </div>
 
-      {/* <Calendar
-        date={new Date("2025-8-1")}
-        localizer={localizer}
-        events={events}
-        formats={formats}
-        startAccessor="start"
-        endAccessor="end"
-        defaultView="week"
-        views={["week"]}
-        components={{
-          week: {
-            header: CustomWeekHeader,
-            event: CustomEvent,
-          },
-        }}
-        eventPropGetter={(event) => {
-          return {
-            style: {
-              backgroundColor: `${colorAutoSelector(event.id)}`,
-              borderRadius: "6px",
-              color: "white",
-            },
-          };
-        }}
-      /> */}
-    </div>
+    //   {/* <Calendar
+    //     date={new Date("2025-8-1")}
+    //     localizer={localizer}
+    //     events={events}
+    //     formats={formats}
+    //     startAccessor="start"
+    //     endAccessor="end"
+    //     defaultView="week"
+    //     views={["week"]}
+    //     components={{
+    //       week: {
+    //         header: CustomWeekHeader,
+    //         event: CustomEvent,
+    //       },
+    //     }}
+    //     eventPropGetter={(event) => {
+    //       return {
+    //         style: {
+    //           backgroundColor: `${colorAutoSelector(event.id)}`,
+    //           borderRadius: "6px",
+    //           color: "white",
+    //         },
+    //       };
+    //     }}
+    //   /> */}
+    // </div>
+    <Swiper
+      slidesPerView={1}
+      spaceBetween={0}
+      className="swiper-container"
+      onSlideChange={(swiper) => {
+        console.log(swiper);
+      }}
+    >
+      {calendarArr.map((item, index) => (
+        <SwiperSlide key={index}>{item}</SwiperSlide>
+      ))}
+    </Swiper>
   );
 };
 

--- a/src/pages/schedule/weekly_schedule/WeeklyScheduleView.tsx
+++ b/src/pages/schedule/weekly_schedule/WeeklyScheduleView.tsx
@@ -1,33 +1,29 @@
-import { Calendar, luxonLocalizer } from "react-big-calendar";
-import { DateTime } from "luxon";
-import { CustomEvent } from "./CustomEvent";
 import "./WeeklyCalendar.scss";
-import CustomWeekHeader from "./CustomWeekHeader";
-import { colorAutoSelector } from "@/utils/colorAutoSelector";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { addWeeks, subWeeks } from "date-fns";
 import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/swiper-bundle.css";
+import WeeklyCalendar from "./WeeklyCalendar";
+import { Virtual } from "swiper/modules";
 
 interface Props {
   schedules: any[];
 }
 
-const localizer = luxonLocalizer(DateTime);
-
-const formats = {
-  timeGutterFormat: (date: Date, culture: string, localizer: any) => {
-    return DateTime.fromJSDate(date).toFormat("H"); // 예: 22
-  },
-};
-
 const WeeklyScheduleView = ({ schedules }: Props) => {
-  const [currentDate, setCurrentDate] = useState(new Date());
-  const prevWeek = subWeeks(currentDate, 1);
-  const nextWeek = addWeeks(currentDate, 1);
+  const [standardDate, setStandardDate] = useState(new Date());
+  const didSkipFirstChange = useRef(false); // 0->1 이동시 handleSlideChange는 발동안되게하는 플래그
+  const swiperRef = useRef(null);
 
-  const [offset, setOffset] = useState(0); // 슬라이딩용 오프셋
-  const touchStartX = useRef<number | null>(null);
+  const [calendarArr, setCalendarArr] = useState(() => {
+    const prev = subWeeks(standardDate, 1);
+    const next = addWeeks(standardDate, 1);
+    return [
+      { week: prev, key: prev.getTime() },
+      { week: standardDate, key: standardDate.getTime() },
+      { week: next, key: next.getTime() },
+    ];
+  });
 
   const events = schedules?.map((item, index) => ({
     id: item.id,
@@ -36,155 +32,77 @@ const WeeklyScheduleView = ({ schedules }: Props) => {
     end: new Date(`${item.date}T${item.endTime}`),
   }));
 
-  const handleTouchStart = (e: React.TouchEvent) => {
-    touchStartX.current = e.touches[0].clientX;
-  };
-
-  const handleTouchEnd = (e: React.TouchEvent) => {
-    if (touchStartX.current === null) return;
-
-    const deltaX = e.changedTouches[0].clientX - touchStartX.current;
-
-    if (deltaX > 50) {
-      setOffset(100); // 오른쪽으로 이동
-      setTimeout(() => {
-        setCurrentDate(prevWeek);
-        setOffset(0);
-      }, 300);
-    } else if (deltaX < -50) {
-      setOffset(-100); // 왼쪽으로 이동
-      setTimeout(() => {
-        setCurrentDate(nextWeek);
-        setOffset(0);
-      }, 300);
+  const handleSlideChange = (swiper) => {
+    if (!didSkipFirstChange.current) {
+      didSkipFirstChange.current = true;
+      return;
     }
 
-    touchStartX.current = null;
+    const { previousIndex, activeIndex } = swiper;
 
-    console.log(offset);
+    setCalendarArr((prevArr) => {
+      let newStandard: Date;
+      let newArr = [...prevArr];
+
+      if (activeIndex > previousIndex) {
+        console.log("next");
+
+        // 다음 주로 이동
+        newStandard = addWeeks(standardDate, 1);
+        // 오른쪽으로 한 칸 추가, 왼쪽 하나 제거
+        const nextWeek = addWeeks(newStandard, 1);
+        newArr.push({ week: nextWeek, key: nextWeek.getTime() });
+        newArr.shift();
+        console.log(newArr);
+      } else {
+        console.log("prev");
+        // 이전 주로 이동
+        newStandard = subWeeks(standardDate, 1);
+        const prevWeek = subWeeks(newStandard, 1);
+        newArr.unshift({ week: prevWeek, key: prevWeek.getTime() });
+        newArr.pop();
+        console.log(newArr);
+      }
+
+      // 기준 날짜 업데이트
+      setStandardDate(newStandard);
+
+      return newArr;
+    });
   };
 
-  const calendarArr = [
-    <Calendar
-      date={prevWeek}
-      localizer={localizer}
-      events={events}
-      formats={formats}
-      startAccessor="start"
-      endAccessor="end"
-      defaultView="week"
-      views={["week"]}
-      components={{
-        week: {
-          header: CustomWeekHeader,
-          event: CustomEvent,
-        },
-      }}
-      eventPropGetter={(event) => {
-        return {
-          style: {
-            backgroundColor: `${colorAutoSelector(event.id)}`,
-            borderRadius: "6px",
-            color: "white",
-          },
-        };
-      }}
-    />,
+  useEffect(() => {
+    if (!swiperRef.current) return;
 
-    <Calendar
-      date={currentDate}
-      localizer={localizer}
-      events={events}
-      formats={formats}
-      startAccessor="start"
-      endAccessor="end"
-      defaultView="week"
-      views={["week"]}
-      components={{
-        week: {
-          header: CustomWeekHeader,
-          event: CustomEvent,
-        },
-      }}
-      eventPropGetter={(event) => {
-        return {
-          style: {
-            backgroundColor: `${colorAutoSelector(event.id)}`,
-            borderRadius: "6px",
-            color: "white",
-          },
-        };
-      }}
-    />,
-    <Calendar
-      date={nextWeek}
-      localizer={localizer}
-      events={events}
-      formats={formats}
-      startAccessor="start"
-      endAccessor="end"
-      defaultView="week"
-      views={["week"]}
-      components={{
-        week: {
-          header: CustomWeekHeader,
-          event: CustomEvent,
-        },
-      }}
-      eventPropGetter={(event) => {
-        return {
-          style: {
-            backgroundColor: `${colorAutoSelector(event.id)}`,
-            borderRadius: "6px",
-            color: "white",
-          },
-        };
-      }}
-    />,
-  ];
+    // DOM 수정 → Swiper에게 알려줌
+    swiperRef.current.update();
+
+    // 한 틱 뒤(다음 페인트 전에) 중앙으로 이동
+    requestAnimationFrame(() => {
+      swiperRef.current?.slideTo(1, 0, false); // runCallbacks=false
+    });
+  }, [calendarArr]);
+
+  useEffect(() => {
+    console.log(calendarArr);
+  }, [calendarArr]);
 
   return (
-    // <div className="calendar-container" onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
-    //   <div className="calendar-slider" style={{ transform: `translateX(${offset}%)` }}>
-    //     <div className="calendar-viewport">{calendaryArr.map((item, index) => item)}</div>
-    //   </div>
-
-    //   {/* <Calendar
-    //     date={new Date("2025-8-1")}
-    //     localizer={localizer}
-    //     events={events}
-    //     formats={formats}
-    //     startAccessor="start"
-    //     endAccessor="end"
-    //     defaultView="week"
-    //     views={["week"]}
-    //     components={{
-    //       week: {
-    //         header: CustomWeekHeader,
-    //         event: CustomEvent,
-    //       },
-    //     }}
-    //     eventPropGetter={(event) => {
-    //       return {
-    //         style: {
-    //           backgroundColor: `${colorAutoSelector(event.id)}`,
-    //           borderRadius: "6px",
-    //           color: "white",
-    //         },
-    //       };
-    //     }}
-    //   /> */}
-    // </div>
     <Swiper
+      onSwiper={(instance) => (swiperRef.current = instance)}
+      observer // MutationObserver 사용
+      observeParents
+      observeSlideChildren // slide 자체의 자식까지 감시
+      initialSlide={1}
       slidesPerView={1}
       spaceBetween={0}
       className="swiper-container"
-      onSlideChange={(swiper) => {
-        console.log(swiper);
-      }}
+      onSlideChangeTransitionEnd={handleSlideChange}
     >
-      {calendarArr.map((item, index) => (
-        <SwiperSlide key={index}>{item}</SwiperSlide>
+      {calendarArr.map(({ week, key }) => (
+        <SwiperSlide key={key}>
+          <WeeklyCalendar week={week} events={events} />
+        </SwiperSlide>
       ))}
     </Swiper>
   );

--- a/src/pages/schedule/weekly_schedule/WeeklyScheduleView.tsx
+++ b/src/pages/schedule/weekly_schedule/WeeklyScheduleView.tsx
@@ -13,6 +13,7 @@ const WeeklyScheduleView = ({ schedules }: Props) => {
   const [standardDate, setStandardDate] = useState(new Date());
   const didSkipFirstChange = useRef(false); // 0->1 이동시 handleSlideChange는 발동안되게하는 플래그
   const swiperRef = useRef(null);
+  const [isSwiping, setIsSwiping] = useState(false);
 
   const [calendarArr, setCalendarArr] = useState(() => {
     const prev = subWeeks(standardDate, 1);
@@ -80,9 +81,15 @@ const WeeklyScheduleView = ({ schedules }: Props) => {
   return (
     <Swiper
       onSwiper={(instance) => (swiperRef.current = instance)}
-      // observer // MutationObserver 사용
-      // observeParents
-      // observeSlideChildren // slide 자체의 자식까지 감시
+      onTouchStart={() => {
+        setIsSwiping(false);
+      }}
+      onSliderFirstMove={() => {
+        setIsSwiping(true);
+      }} // 첫 move 시점
+      onTouchEnd={() => {
+        setIsSwiping(false);
+      }}
       observer={false}
       observeParents={false}
       observeSlideChildren={false}
@@ -101,7 +108,7 @@ const WeeklyScheduleView = ({ schedules }: Props) => {
           {/* <div onPointerUpCapture={(e) => e.stopPropagation()}>
             <WeeklyCalendar week={week} events={events} />
           </div> */}
-          <WeeklyCalendar week={week} events={events} />
+          <WeeklyCalendar week={week} events={events} blockInteraction={isSwiping} />
         </SwiperSlide>
       ))}
     </Swiper>

--- a/src/pages/schedule/weekly_schedule/WeeklyScheduleView.tsx
+++ b/src/pages/schedule/weekly_schedule/WeeklyScheduleView.tsx
@@ -1,5 +1,5 @@
 import "./WeeklyCalendar.scss";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { addWeeks, subWeeks } from "date-fns";
 import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/swiper-bundle.css";

--- a/src/pages/schedule/weekly_schedule/WeeklyScheduleView.tsx
+++ b/src/pages/schedule/weekly_schedule/WeeklyScheduleView.tsx
@@ -4,6 +4,8 @@ import { CustomEvent } from "./CustomEvent";
 import "./WeeklyCalendar.scss";
 import CustomWeekHeader from "./CustomWeekHeader";
 import { colorAutoSelector } from "@/utils/colorAutoSelector";
+import { useRef, useState } from "react";
+import { addWeeks, subWeeks } from "date-fns";
 
 interface Props {
   schedules: any[];
@@ -18,6 +20,13 @@ const formats = {
 };
 
 const WeeklyScheduleView = ({ schedules }: Props) => {
+  const [currentDate, setCurrentDate] = useState(new Date());
+  const prevWeek = subWeeks(currentDate, 1);
+  const nextWeek = addWeeks(currentDate, 1);
+
+  const [offset, setOffset] = useState(0); // 슬라이딩용 오프셋
+  const touchStartX = useRef<number | null>(null);
+
   const events = schedules.map((item, index) => ({
     id: item.id,
     title: item.scheduleName,
@@ -25,8 +34,35 @@ const WeeklyScheduleView = ({ schedules }: Props) => {
     end: new Date(`${item.date}T${item.endTime}`),
   }));
 
-  return (
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+  };
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (touchStartX.current === null) return;
+
+    const deltaX = e.changedTouches[0].clientX - touchStartX.current;
+
+    if (deltaX > 50) {
+      setOffset(100); // 오른쪽으로 이동
+      setTimeout(() => {
+        setCurrentDate(prevWeek);
+        setOffset(0);
+      }, 300);
+    } else if (deltaX < -50) {
+      setOffset(-100); // 왼쪽으로 이동
+      setTimeout(() => {
+        setCurrentDate(nextWeek);
+        setOffset(0);
+      }, 300);
+    }
+
+    touchStartX.current = null;
+  };
+
+  const calendaryArr = [
     <Calendar
+      date={prevWeek}
       localizer={localizer}
       events={events}
       formats={formats}
@@ -49,7 +85,92 @@ const WeeklyScheduleView = ({ schedules }: Props) => {
           },
         };
       }}
-    />
+    />,
+
+    <Calendar
+      date={currentDate}
+      localizer={localizer}
+      events={events}
+      formats={formats}
+      startAccessor="start"
+      endAccessor="end"
+      defaultView="week"
+      views={["week"]}
+      components={{
+        week: {
+          header: CustomWeekHeader,
+          event: CustomEvent,
+        },
+      }}
+      eventPropGetter={(event) => {
+        return {
+          style: {
+            backgroundColor: `${colorAutoSelector(event.id)}`,
+            borderRadius: "6px",
+            color: "white",
+          },
+        };
+      }}
+    />,
+    <Calendar
+      date={nextWeek}
+      localizer={localizer}
+      events={events}
+      formats={formats}
+      startAccessor="start"
+      endAccessor="end"
+      defaultView="week"
+      views={["week"]}
+      components={{
+        week: {
+          header: CustomWeekHeader,
+          event: CustomEvent,
+        },
+      }}
+      eventPropGetter={(event) => {
+        return {
+          style: {
+            backgroundColor: `${colorAutoSelector(event.id)}`,
+            borderRadius: "6px",
+            color: "white",
+          },
+        };
+      }}
+    />,
+  ];
+
+  return (
+    <div className="calendar-container" onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
+      <div className="calendar-slider" style={{ transform: `translateX(${offset}%)` }}>
+        <div className="calendar-viewport">{calendaryArr.map((item, index) => item)}</div>
+      </div>
+
+      {/* <Calendar
+        date={new Date("2025-8-1")}
+        localizer={localizer}
+        events={events}
+        formats={formats}
+        startAccessor="start"
+        endAccessor="end"
+        defaultView="week"
+        views={["week"]}
+        components={{
+          week: {
+            header: CustomWeekHeader,
+            event: CustomEvent,
+          },
+        }}
+        eventPropGetter={(event) => {
+          return {
+            style: {
+              backgroundColor: `${colorAutoSelector(event.id)}`,
+              borderRadius: "6px",
+              color: "white",
+            },
+          };
+        }}
+      /> */}
+    </div>
   );
 };
 

--- a/src/pages/schedule/weekly_schedule/WeeklyScheduleView.tsx
+++ b/src/pages/schedule/weekly_schedule/WeeklyScheduleView.tsx
@@ -1,10 +1,9 @@
 import "./WeeklyCalendar.scss";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { addWeeks, subWeeks } from "date-fns";
 import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/swiper-bundle.css";
 import WeeklyCalendar from "./WeeklyCalendar";
-import { Virtual } from "swiper/modules";
 
 interface Props {
   schedules: any[];
@@ -25,7 +24,7 @@ const WeeklyScheduleView = ({ schedules }: Props) => {
     ];
   });
 
-  const events = schedules?.map((item, index) => ({
+  const events = schedules?.map((item, _) => ({
     id: item.id,
     title: item.scheduleName,
     start: new Date(`${item.date}T${item.startTime}`),
@@ -45,23 +44,18 @@ const WeeklyScheduleView = ({ schedules }: Props) => {
       let newArr = [...prevArr];
 
       if (activeIndex > previousIndex) {
-        console.log("next");
-
         // 다음 주로 이동
         newStandard = addWeeks(standardDate, 1);
         // 오른쪽으로 한 칸 추가, 왼쪽 하나 제거
         const nextWeek = addWeeks(newStandard, 1);
         newArr.push({ week: nextWeek, key: nextWeek.getTime() });
         newArr.shift();
-        console.log(newArr);
       } else {
-        console.log("prev");
         // 이전 주로 이동
         newStandard = subWeeks(standardDate, 1);
         const prevWeek = subWeeks(newStandard, 1);
         newArr.unshift({ week: prevWeek, key: prevWeek.getTime() });
         newArr.pop();
-        console.log(newArr);
       }
 
       // 기준 날짜 업데이트
@@ -83,24 +77,30 @@ const WeeklyScheduleView = ({ schedules }: Props) => {
     });
   }, [calendarArr]);
 
-  useEffect(() => {
-    console.log(calendarArr);
-  }, [calendarArr]);
-
   return (
     <Swiper
       onSwiper={(instance) => (swiperRef.current = instance)}
-      observer // MutationObserver 사용
-      observeParents
-      observeSlideChildren // slide 자체의 자식까지 감시
+      // observer // MutationObserver 사용
+      // observeParents
+      // observeSlideChildren // slide 자체의 자식까지 감시
+      observer={false}
+      observeParents={false}
+      observeSlideChildren={false}
       initialSlide={1}
       slidesPerView={1}
       spaceBetween={0}
       className="swiper-container"
       onSlideChangeTransitionEnd={handleSlideChange}
+      preventClicks={false}
+      preventClicksPropagation={false}
+      touchStartPreventDefault={false}
+      touchMoveStopPropagation={false}
     >
       {calendarArr.map(({ week, key }) => (
         <SwiperSlide key={key}>
+          {/* <div onPointerUpCapture={(e) => e.stopPropagation()}>
+            <WeeklyCalendar week={week} events={events} />
+          </div> */}
           <WeeklyCalendar week={week} events={events} />
         </SwiperSlide>
       ))}

--- a/src/store/scheduleStore.ts
+++ b/src/store/scheduleStore.ts
@@ -1,0 +1,24 @@
+import type { ScheduleDataType } from "@/types/schedule-data-type";
+import { create } from "zustand";
+
+export const API_BASE = import.meta.env.VITE_API_BASE_URL;
+
+interface ScheduleState {
+  scheduleList: ScheduleDataType[];
+  fetchSchedules: (id: number) => void;
+}
+
+export const useScheduleStore = create<ScheduleState>()((set) => ({
+  scheduleList: [],
+  fetchSchedules: async (id) => {
+    const res = await fetch(`${API_BASE}/schedules?id=${id}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    const data = await res.json();
+    // console.log(data.data);
+    set({ scheduleList: data.data });
+  },
+}));

--- a/src/types/schedule-data-type.ts
+++ b/src/types/schedule-data-type.ts
@@ -1,0 +1,5 @@
+export interface ScheduleDataType {
+  title: string;
+  startAt: string;
+  endAt: string;
+}

--- a/src/utils/dateFormatter.ts
+++ b/src/utils/dateFormatter.ts
@@ -1,7 +1,16 @@
+import { format } from "date-fns";
+import { ko } from "date-fns/locale";
+
 export const dateFormatter = (input) => {
   const date = new Date(input);
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0");
   const day = String(date.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
+};
+
+export const scheduleStringFormatter = (input) => {
+  const formattedDate = format(input, "MM월 dd일(EEE)", { locale: ko });
+  const formattedTime = format(input, "a hh:mm").replace("AM", "오전").replace("PM", "오후");
+  return `${formattedDate} ${formattedTime}`;
 };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+declare module "swiper/swiper.scss";
+declare module "*.scss";
+declare module "*.css";


### PR DESCRIPTION
## #️⃣연관된 이슈

#26 

## 📝작업 내용

* 일정 생성 슬라이더와 관련된 컴포넌트를 개발하였습니다
* 관련 컴포넌트는 /src/pages/schedule/schedule_creation에 모여있습니다
* ScheduleCreationPage를 가장 상위 컴포넌트로 하여 계층적으로 View -> Card 등으로 내려가는 구조입니다
* Weekly 스케줄 페이지의 WeeklyCalendar에서 특정 시간 범위를 홀드 앤 드래그로 상호작용하면, 그 범위가 설정된 일정 CRUD 슬라이더가 렌더링되게 됩니다
   * 혹은 이미 생성된 일정을 클릭하면, 해당 일정을 수정하거나 삭제할 수 있는 일정 CRUD 슬라이더가 렌더링됩니다

### 스크린샷 (선택)

https://github.com/user-attachments/assets/282bc8a4-4ed1-4b19-8ee3-cf3c535b3f45


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
