### PR TITLE
feat : 로그인 페이지에 개인정보 처리방침 페이지로 넘어가는 UI 추가

### DIFF
--- a/src/pages/login/components/LoginContainer.tsx
+++ b/src/pages/login/components/LoginContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import Meetcha_banner from "../../../components/Meetcha_banner";
 import Continue_Google from "./Continue_Google";
 import Continue_des from "./Continue_des";
@@ -21,6 +21,9 @@ const LoginContainer = () => {
           <Continue_Google />
           <Continue_des />
         </div>
+      </div>
+      <div className="privacyBtn" onClick={() => navigate("/privacy")}>
+        개인정보 처리방침
       </div>
     </div>
   );

--- a/src/pages/login/styles/login.scss
+++ b/src/pages/login/styles/login.scss
@@ -1,63 +1,74 @@
-
-*{
-    margin:0;
+* {
+  margin: 0;
 }
 
+$background-color: #fff9f1;
+$signiture-color: #ff6200;
 
-$background-color: #FFF9F1;
-$signiture-color: #FF6200;
+.login_container {
+  width: 100%;
+  height: 100vh;
+  background: $background-color;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 
-.login_container{    
-    width: 100%;
-    height: 100vh;
-    background: $background-color;
+  > .flex_container1 {
     display: flex;
     flex-direction: column;
-    justify-content: center;
-    
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 5.2rem;
 
-    >.flex_container1{
+    > .flex_container2 {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+
+      > .google_button {
+        height: 3.1rem;
+        border: 1px solid $signiture-color;
+
+        border-radius: 10px;
+        padding: 0 0.9375rem 0 0.9375rem;
+        background-color: #ffffff;
         display: flex;
-        flex-direction: column;
         align-items: center;
-        gap:1rem;
-        margin-bottom: 5.2rem;
-    
-        >.flex_container2{
-            display: flex;
-            flex-direction: column;
-            gap:1rem;
+        gap: 0.9375rem;
 
-            > .google_button {
-                
-                height: 3.1rem;
-                border: 1px solid $signiture-color;
-
-                border-radius: 10px;
-                padding:0 0.9375rem 0 0.9375rem;
-                background-color: #FFFFFF;
-                display: flex;
-                align-items: center;
-                gap:0.9375rem;
-                
-                >p{
-                    font-family: Roboto;
-                    font-weight: 500;
-                    font-size: 20px;
-                    line-height: 100%;
-                    letter-spacing: 0%;
-                    color: $signiture-color;
-                }
-            }
-        
-            > .continue_desc{
-                text-align: center;
-                font-family: Pretendard;
-                font-weight: 400;   
-                font-size: 11px;
-                line-height: 100%;
-                letter-spacing: 0%;
-            }
+        > p {
+          font-family: Roboto;
+          font-weight: 500;
+          font-size: 20px;
+          line-height: 100%;
+          letter-spacing: 0%;
+          color: $signiture-color;
         }
+      }
+
+      > .continue_desc {
+        text-align: center;
+        font-family: Pretendard;
+        font-weight: 400;
+        font-size: 11px;
+        line-height: 100%;
+        letter-spacing: 0%;
+      }
     }
+  }
+
+  > .privacyBtn {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: 20px;
+
+    color: $color-orange-5;
+    text-decoration: underline;
+    text-decoration-color: $color-orange-5;
+
+    font-family: Pretendard;
+    font-size: small;
+    font-weight: 600;
+  }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#196 

## 📝작업 내용

* 로그인 페이지에 개인정보 처리방침 페이지로 넘어가는 UI 추가

### 스크린샷 (선택)
<img width="358" height="795" alt="image" src="https://github.com/user-attachments/assets/31f56a6e-cc1a-4e69-9fb3-d8578248dc1b" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
