### PR TITLE
feat: [KAN-19] 오늘 날짜 이전 캘린더 타일 비활성화

### DIFF
--- a/src/pages/meeting/create/MeetingOptionCard.tsx
+++ b/src/pages/meeting/create/MeetingOptionCard.tsx
@@ -22,18 +22,29 @@ const MeetingOptionCard = ({ title, icon, data, type, dataSetter }: Props) => {
   const contentRef = useRef<HTMLDivElement>(null); // 사용자 입력 컴포넌트 크기 영역 참조 변수
   let inputComponent = null; // 사용자 입력 방식에 따른 컴포넌트(input태그, 달력, ...)
 
+  const isPreviousDate = (date: Date) => {
+    return date.getTime() < new Date().getTime() && date.getDate() < new Date().getDate();
+  };
+
   switch (type) {
     case 0:
       inputComponent = (
         <TextInputComponent
-          dataSetter={dataSetter as React.Dispatch<React.SetStateAction<string>>}
+          dataSetter={
+            dataSetter as React.Dispatch<React.SetStateAction<string>>
+          }
         />
       );
       break;
     case 1:
       inputComponent = (
         <CalendarMultipleInputComponent
-          dataSetter={dataSetter as React.Dispatch<React.SetStateAction<string[]>>}
+          dataSetter={
+            dataSetter as React.Dispatch<React.SetStateAction<string[]>>
+          }
+          tileDisabled={({ date }) => {
+            return isPreviousDate(date);
+          }}
         />
       );
       break;
@@ -52,25 +63,32 @@ const MeetingOptionCard = ({ title, icon, data, type, dataSetter }: Props) => {
       inputComponent = (
         <>
           <CalendarInputComponent
-            dataSetter={dataSetter as React.Dispatch<React.SetStateAction<string>>}
+            dataSetter={
+              dataSetter as React.Dispatch<React.SetStateAction<string>>
+            }
+            tileDisabled={({ date }) => {
+              return isPreviousDate(date);
+            }}
           />
           <TimePicker
             onChange={(item) => {
-              (dataSetter as React.Dispatch<React.SetStateAction<string>>)((prev) => {
-                if (!prev) {
-                  // 초기의 빈 문자열인 경우
-                  return item;
-                } else if (prev.includes("T")) {
-                  // 날짜+시간이 이미 입력된 경우
-                  return `${prev?.split("T")[0]}T${item}`;
-                } else if (prev.includes(":")) {
-                  // 시간만 입력된 경우
-                  return item;
-                } else {
-                  // 날짜만 입력된 경우
-                  return `${prev}T${item}`;
+              (dataSetter as React.Dispatch<React.SetStateAction<string>>)(
+                (prev) => {
+                  if (!prev) {
+                    // 초기의 빈 문자열인 경우
+                    return item;
+                  } else if (prev.includes("T")) {
+                    // 날짜+시간이 이미 입력된 경우
+                    return `${prev?.split("T")[0]}T${item}`;
+                  } else if (prev.includes(":")) {
+                    // 시간만 입력된 경우
+                    return item;
+                  } else {
+                    // 날짜만 입력된 경우
+                    return `${prev}T${item}`;
+                  }
                 }
-              });
+              );
             }}
             ampm={false}
             minRange={1}
@@ -81,7 +99,9 @@ const MeetingOptionCard = ({ title, icon, data, type, dataSetter }: Props) => {
     case 4:
       inputComponent = (
         <ProjectInputComponent
-          dataSetter={dataSetter as React.Dispatch<React.SetStateAction<string>>}
+          dataSetter={
+            dataSetter as React.Dispatch<React.SetStateAction<string>>
+          }
         />
       );
   }
@@ -120,14 +140,23 @@ const MeetingOptionCard = ({ title, icon, data, type, dataSetter }: Props) => {
   return (
     <div
       className={
-        expanded ? `${styles.expanded} ${styles.meetingOptionCard}` : styles.meetingOptionCard
+        expanded
+          ? `${styles.expanded} ${styles.meetingOptionCard}`
+          : styles.meetingOptionCard
       }
     >
-      <div className={styles.meetingOptionCard__top} onClick={() => setExpanded((prev) => !prev)}>
+      <div
+        className={styles.meetingOptionCard__top}
+        onClick={() => setExpanded((prev) => !prev)}
+      >
         <div className={styles.meetingOptionCard__top__icon}>{icon}</div>
         <div className={styles.meetingOptionCard__top__data}>
-          <div className={styles.meetingOptionCard__top__data__label}>{title}</div>
-          <div className={styles.meetingOptionCard__top__data__value}>{formatData(data)}</div>
+          <div className={styles.meetingOptionCard__top__data__label}>
+            {title}
+          </div>
+          <div className={styles.meetingOptionCard__top__data__value}>
+            {formatData(data)}
+          </div>
         </div>
         <div className={styles.meetingOptionCard__top__downArrow}>
           <DownArrow />

--- a/src/pages/meeting/create/input_component/CalendarInputComponent.tsx
+++ b/src/pages/meeting/create/input_component/CalendarInputComponent.tsx
@@ -1,14 +1,14 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ComponentProps } from "react";
 import Calendar from "react-calendar";
 import "./CalendarInputComponent.scss";
 import { dateFormatter } from "@/utils/dateFormatter";
 
-interface Props {
+interface Props extends Omit<ComponentProps<typeof Calendar>, "onClickDay" | "tileClassName" | "formatDay" > {
   dataSetter:
     | React.Dispatch<React.SetStateAction<string>>
     | React.Dispatch<React.SetStateAction<string[]>>;
 }
-const CalendarInputComponent = ({ dataSetter }: Props) => {
+const CalendarInputComponent = ({ dataSetter,...restProps }: Props) => {
   const [clickedDay, setClickedDay] = useState<string>();
 
   useEffect(() => {
@@ -41,6 +41,7 @@ const CalendarInputComponent = ({ dataSetter }: Props) => {
             return "custom-active";
           }
         }}
+        {...restProps}
       />
     </div>
   );

--- a/src/pages/meeting/create/input_component/CalendarMultipleInputComponent.tsx
+++ b/src/pages/meeting/create/input_component/CalendarMultipleInputComponent.tsx
@@ -1,14 +1,14 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ComponentProps } from "react";
 import Calendar from "react-calendar";
 import "./CalendarMultipleInputComponent.scss";
 import { dateFormatter } from "@/utils/dateFormatter";
 
-interface Props {
+interface Props extends Omit<ComponentProps<typeof Calendar>, "onClickDay" | "tileClassName" | "formatDay" > {
   dataSetter:
     | React.Dispatch<React.SetStateAction<string>>
     | React.Dispatch<React.SetStateAction<string[]>>;
 }
-const CalendarMultipleInputComponent = ({ dataSetter }: Props) => {
+const CalendarMultipleInputComponent = ({ dataSetter,...restProps }: Props) => {
   const [clickedDays, setClickedDays] = useState<string[]>([]);
 
   const clickDaySaver = (value: Date) => {
@@ -34,6 +34,7 @@ const CalendarMultipleInputComponent = ({ dataSetter }: Props) => {
             return "custom-active";
           }
         }}
+        {...restProps}
       />
     </div>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
KAN-19

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
후보시간 및 참여마감 시간 캘린더에서 오늘 이전 날짜를 disable 처리합니다.

이를 위해 Calendar컴포넌트의 props를 외부로 노출시켰습니다. 기존 구현된 props는 Omit으로 제외시킵니다. 이를 통해 확장 가능한 논리 주입이 가능합니다.
두 컴포넌트 모두 이 이슈에 대한 동일한 요구사항을 가지고 있어 오늘 날짜와 비교하는 함수를 추가했습니다. 


### 스크린샷 (선택)

<img width="1786" height="724" alt="image" src="https://github.com/user-attachments/assets/4961c868-4156-435a-b32c-f42cc0413743" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 비고
- TimePicker를 사용하는 투표 마감시간의 경우, 현재 시간과 비교해 disable 처리하는 작업이 필요합니다.
- 후보 날짜 & 참여마감시간의 상호작용 disable이 가능하나, 현재 코드 구조상 서로의 폼 밸루에 대한 상호작용하는 기능을 구현하기 어렵습니다. 
   - 후보 날자가 입력됐으면, 참여 마감 시간은 후보날짜 이전이여야한다.
   - 참여 마감시간이 입력됐으면, 후보 날짜는 참여 마감 시간 이후여야한다.
