### PR TITLE
Fix : [KAN-31] 미팅 생성 페이지 관련 오류 수정 및 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "luxon": "^3.7.1",
         "match-sorter": "^8.0.3",
         "msw": "^2.10.4",
+        "normalize.css": "^8.0.1",
         "react": "^19.1.0",
         "react-big-calendar": "^1.19.4",
         "react-calendar": "^6.0.0",
@@ -4232,6 +4233,12 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
       "license": "MIT"
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "luxon": "^3.7.1",
     "match-sorter": "^8.0.3",
     "msw": "^2.10.4",
+    "normalize.css": "^8.0.1",
     "react": "^19.1.0",
     "react-big-calendar": "^1.19.4",
     "react-calendar": "^6.0.0",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import "./assets/styles/main.scss";
 import { GoogleOAuthProvider } from "@react-oauth/google";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { toast, ToastContainer } from "react-toastify";
+import "normalize.css";
 
 export const queryClient = new QueryClient({
   defaultOptions: {

--- a/src/pages/meeting/create/MeetingCreationView.module.scss
+++ b/src/pages/meeting/create/MeetingCreationView.module.scss
@@ -10,6 +10,8 @@
   justify-content: start;
   gap: 24px;
 
+  overflow: scroll;
+
   &__inputTag {
     width: 100%;
     height: 2.5rem;
@@ -36,8 +38,6 @@
     gap: 12px;
 
     padding-bottom: 1rem;
-
-    overflow: scroll;
   }
 }
 

--- a/src/pages/meeting/create/MeetingCreationView.tsx
+++ b/src/pages/meeting/create/MeetingCreationView.tsx
@@ -3,11 +3,7 @@ import styles from "./MeetingCreationView.module.scss";
 import MeetingOptionCard from "./MeetingOptionCard";
 import type { MeetingSendData } from "./MeetingCreationPage";
 import { cardDataSet } from "./constants/MeetingCreation.constants";
-import {
-  deadlineParse,
-  durationMinutesParse,
-  projectDataParse,
-} from "@/utils/MeetingCreationUtils";
+import { deadlineParse, durationMinutesParse, projectDataParse } from "@/utils/MeetingCreationUtils";
 
 interface Props {
   setAllDataReserved: React.Dispatch<React.SetStateAction<boolean>>;
@@ -32,12 +28,7 @@ const MeetingCreationView = ({ setAllDataReserved, setCompleteData }: Props) => 
   };
 
   useEffect(() => {
-    if (
-      meetingTitle &&
-      meetingCandidateDates.length > 0 &&
-      durationMinutes &&
-      deadlineParse(deadline)
-    ) {
+    if (meetingTitle && meetingCandidateDates.length > 0 && durationMinutes && deadlineParse(deadline)) {
       setAllDataReserved(true);
       setCompleteData({
         title: meetingTitle,
@@ -48,14 +39,7 @@ const MeetingCreationView = ({ setAllDataReserved, setCompleteData }: Props) => 
         projectId: projectDataParse(projectData),
       });
     }
-  }, [
-    meetingTitle,
-    meetingDescription,
-    meetingCandidateDates,
-    durationMinutes,
-    deadline,
-    projectData,
-  ]);
+  }, [meetingTitle, meetingDescription, meetingCandidateDates, durationMinutes, deadline, projectData]);
 
   return (
     <div className={styles.meetingCreationView}>
@@ -78,6 +62,7 @@ const MeetingCreationView = ({ setAllDataReserved, setCompleteData }: Props) => 
             type={item.id}
             clickedCardNum={clickedCardNum}
             setCardClickedNum={setClickedCardNum}
+            meetingCandidateDates={meetingCandidateDates}
           />
         ))}
       </div>

--- a/src/pages/meeting/create/MeetingCreationView.tsx
+++ b/src/pages/meeting/create/MeetingCreationView.tsx
@@ -2,8 +2,12 @@ import React, { useEffect, useState } from "react";
 import styles from "./MeetingCreationView.module.scss";
 import MeetingOptionCard from "./MeetingOptionCard";
 import type { MeetingSendData } from "./MeetingCreationPage";
-import { parse } from "date-fns/parse";
 import { cardDataSet } from "./constants/MeetingCreation.constants";
+import {
+  deadlineParse,
+  durationMinutesParse,
+  projectDataParse,
+} from "@/utils/MeetingCreationUtils";
 
 interface Props {
   setAllDataReserved: React.Dispatch<React.SetStateAction<boolean>>;
@@ -17,6 +21,7 @@ const MeetingCreationView = ({ setAllDataReserved, setCompleteData }: Props) => 
   const [durationMinutes, setDurationMinutes] = useState<string>("");
   const [deadline, setDeadline] = useState<string>("");
   const [projectData, setProjectData] = useState<string>(null);
+  const [clickedCardNum, setClickedCardNum] = useState<number>(null); // 미팅 카드 중 유저가 클릭한 카드의 번호
 
   const stateMapping = {
     description: { data: meetingDescription, dataSetter: setMeetingDescription },
@@ -26,26 +31,6 @@ const MeetingCreationView = ({ setAllDataReserved, setCompleteData }: Props) => 
     project: { data: projectData, dataSetter: setProjectData },
   };
 
-  const projectDataParse = (project: string) => {
-    if (!project) return null;
-    const index = project.indexOf(" ");
-    return project.slice(0, index);
-  };
-
-  const durationMinutesParse = (durationMinutes: string) => {
-    const parsedDate = parse(durationMinutes, "HH:mm", new Date()); // duration은 숫자로 파싱하면서 총 "분"으로 변환
-    return parsedDate.getHours() * 60 + parsedDate.getMinutes();
-  };
-
-  const deadlineParse = (deadline: string) => {
-    if (!deadline) return null;
-    if (!deadline.includes("T")) return null;
-    const [date, time] = deadline?.split("T");
-    const [hour, minute] = time?.split(":");
-    const paddedTime = hour?.padStart(2, "0") + ":" + minute;
-    return date + "T" + paddedTime;
-  };
-  //
   useEffect(() => {
     if (
       meetingTitle &&
@@ -91,6 +76,8 @@ const MeetingCreationView = ({ setAllDataReserved, setCompleteData }: Props) => 
             data={stateMapping[item.stateKey as keyof typeof stateMapping].data}
             dataSetter={stateMapping[item.stateKey as keyof typeof stateMapping].dataSetter}
             type={item.id}
+            clickedCardNum={clickedCardNum}
+            setCardClickedNum={setClickedCardNum}
           />
         ))}
       </div>

--- a/src/pages/meeting/create/MeetingCreationView.tsx
+++ b/src/pages/meeting/create/MeetingCreationView.tsx
@@ -1,12 +1,9 @@
 import React, { useEffect, useState } from "react";
 import styles from "./MeetingCreationView.module.scss";
-import Pencil from "@assets/pencil.svg?react";
-import Calendar from "@assets/calendar.svg?react";
-import Clock from "@assets/clock.svg?react";
-import Watch from "@assets/watch.svg?react";
 import MeetingOptionCard from "./MeetingOptionCard";
 import type { MeetingSendData } from "./MeetingCreationPage";
 import { parse } from "date-fns/parse";
+import { cardDataSet } from "./constants/MeetingCreation.constants";
 
 interface Props {
   setAllDataReserved: React.Dispatch<React.SetStateAction<boolean>>;
@@ -21,56 +18,26 @@ const MeetingCreationView = ({ setAllDataReserved, setCompleteData }: Props) => 
   const [deadline, setDeadline] = useState<string>("");
   const [projectData, setProjectData] = useState<string>(null);
 
-  const cardDataSet = [
-    {
-      id: 0,
-      title: "미팅 설명",
-      icon: <Pencil />,
-      data: meetingDescription,
-      dataSetter: setMeetingDescription,
-    },
-    {
-      id: 1,
-      title: "미팅 후보 날짜",
-      icon: <Calendar />,
-      data: meetingCandidateDates,
-      dataSetter: setMeetingCandidateDates,
-    },
-    {
-      id: 2,
-      title: "미팅 진행 시간",
-      icon: <Clock />,
-      data: durationMinutes,
-      dataSetter: setDurationMinutes,
-    },
-    {
-      id: 3,
-      title: "투표 마감 시간",
-      icon: <Watch />,
-      data: deadline,
-      dataSetter: setDeadline,
-    },
-    {
-      id: 4,
-      title: "프로젝트",
-      icon: <Watch />,
-      data: projectData,
-      dataSetter: setProjectData,
-    },
-  ];
-  //
-  const projectDataParse = (project) => {
+  const stateMapping = {
+    description: { data: meetingDescription, dataSetter: setMeetingDescription },
+    candidateDates: { data: meetingCandidateDates, dataSetter: setMeetingCandidateDates },
+    durationMinutes: { data: durationMinutes, dataSetter: setDurationMinutes },
+    deadline: { data: deadline, dataSetter: setDeadline },
+    project: { data: projectData, dataSetter: setProjectData },
+  };
+
+  const projectDataParse = (project: string) => {
     if (!project) return null;
     const index = project.indexOf(" ");
     return project.slice(0, index);
   };
 
-  const durationMinutesParse = (durationMinutes) => {
+  const durationMinutesParse = (durationMinutes: string) => {
     const parsedDate = parse(durationMinutes, "HH:mm", new Date()); // duration은 숫자로 파싱하면서 총 "분"으로 변환
     return parsedDate.getHours() * 60 + parsedDate.getMinutes();
   };
 
-  const deadlineParse = (deadline) => {
+  const deadlineParse = (deadline: string) => {
     if (!deadline) return null;
     if (!deadline.includes("T")) return null;
     const [date, time] = deadline?.split("T");
@@ -121,8 +88,8 @@ const MeetingCreationView = ({ setAllDataReserved, setCompleteData }: Props) => 
             key={item.id}
             title={item.title}
             icon={item.icon}
-            data={item.data}
-            dataSetter={item.dataSetter}
+            data={stateMapping[item.stateKey as keyof typeof stateMapping].data}
+            dataSetter={stateMapping[item.stateKey as keyof typeof stateMapping].dataSetter}
             type={item.id}
           />
         ))}

--- a/src/pages/meeting/create/MeetingOptionCard.module.scss
+++ b/src/pages/meeting/create/MeetingOptionCard.module.scss
@@ -64,10 +64,6 @@
       &__value {
         width: 100%;
 
-        display: flex;
-        align-items: center;
-        justify-content: start;
-
         font-size: 17px;
         font-style: normal;
         font-weight: 600;

--- a/src/pages/meeting/create/MeetingOptionCard.tsx
+++ b/src/pages/meeting/create/MeetingOptionCard.tsx
@@ -12,12 +12,22 @@ interface Props {
   icon: React.ReactNode;
   data: string | string[];
   type: number;
+  clickedCardNum: number;
+  setCardClickedNum: React.Dispatch<React.SetStateAction<number>>;
   dataSetter:
     | React.Dispatch<React.SetStateAction<string>>
     | React.Dispatch<React.SetStateAction<string[]>>;
 }
 
-const MeetingOptionCard = ({ title, icon, data, type, dataSetter }: Props) => {
+const MeetingOptionCard = ({
+  title,
+  icon,
+  data,
+  type,
+  clickedCardNum,
+  setCardClickedNum,
+  dataSetter,
+}: Props) => {
   const [expanded, setExpanded] = useState<boolean>(false); // 카드가 펼쳐졌는지 여부
   const contentRef = useRef<HTMLDivElement>(null); // 사용자 입력 컴포넌트 크기 영역 참조 변수
   let inputComponent = null; // 사용자 입력 방식에 따른 컴포넌트(input태그, 달력, ...)
@@ -88,20 +98,28 @@ const MeetingOptionCard = ({ title, icon, data, type, dataSetter }: Props) => {
 
   // UI상의 데이터 표시를 위한 데이터 포맷 로직
   const formatData = (data: Props["data"]) => {
-    if (Array.isArray(data)) {
+    if (type === 1 && Array.isArray(data)) {
       return data.join(", ");
-    }
-    if (type === 3 && data && data.includes("T")) {
-      const [date, time] = data?.split("T");
+    } else if (type === 3 && typeof data === "string" && data.includes("T")) {
+      const [date, time] = data.split("T");
       return `${date} ${time}`;
-    }
-    if (type === 4) {
+    } else if (type === 4) {
       if (!data) return;
       const index = data.indexOf(" ");
       return data.slice(index);
+    } else {
+      return data;
     }
-    return data;
   };
+
+  const cardClickHandler = () => {
+    setExpanded((prev) => !prev);
+    setCardClickedNum(type);
+  };
+
+  useEffect(() => {
+    if (clickedCardNum !== type) setExpanded(false);
+  }, [clickedCardNum]);
 
   // 카드의 높이를 구하는 로직(애니메이션 적용 위함)
   useEffect(() => {
@@ -123,7 +141,7 @@ const MeetingOptionCard = ({ title, icon, data, type, dataSetter }: Props) => {
         expanded ? `${styles.expanded} ${styles.meetingOptionCard}` : styles.meetingOptionCard
       }
     >
-      <div className={styles.meetingOptionCard__top} onClick={() => setExpanded((prev) => !prev)}>
+      <div className={styles.meetingOptionCard__top} onClick={cardClickHandler}>
         <div className={styles.meetingOptionCard__top__icon}>{icon}</div>
         <div className={styles.meetingOptionCard__top__data}>
           <div className={styles.meetingOptionCard__top__data__label}>{title}</div>

--- a/src/pages/meeting/create/MeetingOptionCard.tsx
+++ b/src/pages/meeting/create/MeetingOptionCard.tsx
@@ -6,6 +6,7 @@ import CalendarMultipleInputComponent from "./input_component/CalendarMultipleIn
 import TimePicker from "../../../components/TimePicker/TimePicker";
 import CalendarInputComponent from "./input_component/CalendarInputComponent";
 import ProjectInputComponent from "./input_component/ProjectInputComponent/ProjectInputComponent";
+import { formatMeetingCardUIData } from "@/utils/MeetingOptionCardUtils";
 
 interface Props {
   title: string;
@@ -14,37 +15,21 @@ interface Props {
   type: number;
   clickedCardNum: number;
   setCardClickedNum: React.Dispatch<React.SetStateAction<number>>;
-  dataSetter:
-    | React.Dispatch<React.SetStateAction<string>>
-    | React.Dispatch<React.SetStateAction<string[]>>;
+  dataSetter: React.Dispatch<React.SetStateAction<string>> | React.Dispatch<React.SetStateAction<string[]>>;
 }
 
-const MeetingOptionCard = ({
-  title,
-  icon,
-  data,
-  type,
-  clickedCardNum,
-  setCardClickedNum,
-  dataSetter,
-}: Props) => {
+const MeetingOptionCard = ({ title, icon, data, type, clickedCardNum, setCardClickedNum, dataSetter }: Props) => {
   const [expanded, setExpanded] = useState<boolean>(false); // 카드가 펼쳐졌는지 여부
   const contentRef = useRef<HTMLDivElement>(null); // 사용자 입력 컴포넌트 크기 영역 참조 변수
   let inputComponent = null; // 사용자 입력 방식에 따른 컴포넌트(input태그, 달력, ...)
 
   switch (type) {
     case 0:
-      inputComponent = (
-        <TextInputComponent
-          dataSetter={dataSetter as React.Dispatch<React.SetStateAction<string>>}
-        />
-      );
+      inputComponent = <TextInputComponent dataSetter={dataSetter as React.Dispatch<React.SetStateAction<string>>} />;
       break;
     case 1:
       inputComponent = (
-        <CalendarMultipleInputComponent
-          dataSetter={dataSetter as React.Dispatch<React.SetStateAction<string[]>>}
-        />
+        <CalendarMultipleInputComponent dataSetter={dataSetter as React.Dispatch<React.SetStateAction<string[]>>} />
       );
       break;
     case 2:
@@ -54,16 +39,15 @@ const MeetingOptionCard = ({
             dataSetter(item);
           }}
           ampm={false}
-          minRange={1}
+          minRange={30}
+          customHour={["1", "3", "5", "7", "9"]}
         />
       );
       break;
     case 3:
       inputComponent = (
         <>
-          <CalendarInputComponent
-            dataSetter={dataSetter as React.Dispatch<React.SetStateAction<string>>}
-          />
+          <CalendarInputComponent dataSetter={dataSetter as React.Dispatch<React.SetStateAction<string>>} />
           <TimePicker
             onChange={(item) => {
               (dataSetter as React.Dispatch<React.SetStateAction<string>>)((prev) => {
@@ -84,33 +68,16 @@ const MeetingOptionCard = ({
             }}
             ampm={false}
             minRange={1}
+            customHour={null}
           />
         </>
       );
       break;
     case 4:
       inputComponent = (
-        <ProjectInputComponent
-          dataSetter={dataSetter as React.Dispatch<React.SetStateAction<string>>}
-        />
+        <ProjectInputComponent dataSetter={dataSetter as React.Dispatch<React.SetStateAction<string>>} />
       );
   }
-
-  // UI상의 데이터 표시를 위한 데이터 포맷 로직
-  const formatData = (data: Props["data"]) => {
-    if (type === 1 && Array.isArray(data)) {
-      return data.join(", ");
-    } else if (type === 3 && typeof data === "string" && data.includes("T")) {
-      const [date, time] = data.split("T");
-      return `${date} ${time}`;
-    } else if (type === 4) {
-      if (!data) return;
-      const index = data.indexOf(" ");
-      return data.slice(index);
-    } else {
-      return data;
-    }
-  };
 
   const cardClickHandler = () => {
     setExpanded((prev) => !prev);
@@ -136,16 +103,12 @@ const MeetingOptionCard = ({
   }, [expanded]);
 
   return (
-    <div
-      className={
-        expanded ? `${styles.expanded} ${styles.meetingOptionCard}` : styles.meetingOptionCard
-      }
-    >
+    <div className={expanded ? `${styles.expanded} ${styles.meetingOptionCard}` : styles.meetingOptionCard}>
       <div className={styles.meetingOptionCard__top} onClick={cardClickHandler}>
         <div className={styles.meetingOptionCard__top__icon}>{icon}</div>
         <div className={styles.meetingOptionCard__top__data}>
           <div className={styles.meetingOptionCard__top__data__label}>{title}</div>
-          <div className={styles.meetingOptionCard__top__data__value}>{formatData(data)}</div>
+          <div className={styles.meetingOptionCard__top__data__value}>{formatMeetingCardUIData(type, data)}</div>
         </div>
         <div className={styles.meetingOptionCard__top__downArrow}>
           <DownArrow />

--- a/src/pages/meeting/create/MeetingOptionCard.tsx
+++ b/src/pages/meeting/create/MeetingOptionCard.tsx
@@ -14,11 +14,21 @@ interface Props {
   data: string | string[];
   type: number;
   clickedCardNum: number;
+  meetingCandidateDates?: string[];
   setCardClickedNum: React.Dispatch<React.SetStateAction<number>>;
   dataSetter: React.Dispatch<React.SetStateAction<string>> | React.Dispatch<React.SetStateAction<string[]>>;
 }
 
-const MeetingOptionCard = ({ title, icon, data, type, clickedCardNum, setCardClickedNum, dataSetter }: Props) => {
+const MeetingOptionCard = ({
+  title,
+  icon,
+  data,
+  type,
+  clickedCardNum,
+  meetingCandidateDates,
+  setCardClickedNum,
+  dataSetter,
+}: Props) => {
   const [expanded, setExpanded] = useState<boolean>(false); // 카드가 펼쳐졌는지 여부
   const contentRef = useRef<HTMLDivElement>(null); // 사용자 입력 컴포넌트 크기 영역 참조 변수
   let inputComponent = null; // 사용자 입력 방식에 따른 컴포넌트(input태그, 달력, ...)
@@ -47,7 +57,10 @@ const MeetingOptionCard = ({ title, icon, data, type, clickedCardNum, setCardCli
     case 3:
       inputComponent = (
         <>
-          <CalendarInputComponent dataSetter={dataSetter as React.Dispatch<React.SetStateAction<string>>} />
+          <CalendarInputComponent
+            dataSetter={dataSetter as React.Dispatch<React.SetStateAction<string>>}
+            meetingCandidateDates={meetingCandidateDates}
+          />
           <TimePicker
             onChange={(item) => {
               (dataSetter as React.Dispatch<React.SetStateAction<string>>)((prev) => {

--- a/src/pages/meeting/create/constants/MeetingCreation.constants.tsx
+++ b/src/pages/meeting/create/constants/MeetingCreation.constants.tsx
@@ -1,0 +1,37 @@
+import Pencil from "@assets/pencil.svg?react";
+import Calendar from "@assets/calendar.svg?react";
+import Clock from "@assets/clock.svg?react";
+import Watch from "@assets/watch.svg?react";
+
+export const cardDataSet = [
+  {
+    id: 0,
+    title: "미팅 설명",
+    icon: <Pencil />,
+    stateKey: "description",
+  },
+  {
+    id: 1,
+    title: "미팅 후보 날짜",
+    icon: <Calendar />,
+    stateKey: "candidateDates",
+  },
+  {
+    id: 2,
+    title: "미팅 진행 시간",
+    icon: <Clock />,
+    stateKey: "durationMinutes",
+  },
+  {
+    id: 3,
+    title: "투표 마감 시간",
+    icon: <Watch />,
+    stateKey: "deadline",
+  },
+  {
+    id: 4,
+    title: "프로젝트",
+    icon: <Watch />,
+    stateKey: "project",
+  },
+];

--- a/src/pages/meeting/create/input_component/CalendarInputComponent.tsx
+++ b/src/pages/meeting/create/input_component/CalendarInputComponent.tsx
@@ -37,7 +37,7 @@ const CalendarInputComponent = ({ meetingCandidateDates, dataSetter }: Props) =>
   return (
     <div className="calendarInputComponent">
       <Calendar
-        formatDay={(locale, date) => date.toLocaleString("en", { day: "numeric" })}
+        formatDay={(_, date) => date.toLocaleString("en", { day: "numeric" })}
         onClickDay={(value) => {
           setClickedDay(dateFormatter(value));
         }}

--- a/src/pages/meeting/create/input_component/CalendarInputComponent.tsx
+++ b/src/pages/meeting/create/input_component/CalendarInputComponent.tsx
@@ -1,15 +1,20 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Calendar from "react-calendar";
 import "./CalendarInputComponent.scss";
 import { dateFormatter } from "@/utils/dateFormatter";
+import { min, startOfDay } from "date-fns";
 
 interface Props {
-  dataSetter:
-    | React.Dispatch<React.SetStateAction<string>>
-    | React.Dispatch<React.SetStateAction<string[]>>;
+  meetingCandidateDates: string[];
+  dataSetter: React.Dispatch<React.SetStateAction<string>> | React.Dispatch<React.SetStateAction<string[]>>;
 }
-const CalendarInputComponent = ({ dataSetter }: Props) => {
+const CalendarInputComponent = ({ meetingCandidateDates, dataSetter }: Props) => {
   const [clickedDay, setClickedDay] = useState<string>();
+  const limitDay = useMemo(() => {
+    if (!meetingCandidateDates?.length) return undefined;
+    const dates = meetingCandidateDates.map((v) => startOfDay(new Date(v)));
+    return min(dates); // Date 객체 반환
+  }, [meetingCandidateDates]);
 
   useEffect(() => {
     (dataSetter as React.Dispatch<React.SetStateAction<string>>)((prev) => {
@@ -41,6 +46,7 @@ const CalendarInputComponent = ({ dataSetter }: Props) => {
             return "custom-active";
           }
         }}
+        tileDisabled={({ date, view }) => view === "month" && startOfDay(date) >= limitDay}
       />
     </div>
   );

--- a/src/utils/MeetingCreationUtils.ts
+++ b/src/utils/MeetingCreationUtils.ts
@@ -1,0 +1,24 @@
+// 서버 쪽 api 포맷에 맞추기 위해 사용자 입력 데이터들을 파싱하는 메서드들
+
+import { parse } from "date-fns";
+
+export const projectDataParse = (project: string) => {
+  if (!project) return null;
+  const index = project.indexOf(" ");
+  return project.slice(0, index);
+};
+
+// duration은 숫자로 파싱하면서 총 "분"으로 변환
+export const durationMinutesParse = (durationMinutes: string) => {
+  const parsedDate = parse(durationMinutes, "HH:mm", new Date());
+  return parsedDate.getHours() * 60 + parsedDate.getMinutes();
+};
+
+export const deadlineParse = (deadline: string) => {
+  if (!deadline) return null;
+  if (!deadline.includes("T")) return null;
+  const [date, time] = deadline?.split("T");
+  const [hour, minute] = time?.split(":");
+  const paddedTime = hour?.padStart(2, "0") + ":" + minute;
+  return date + "T" + paddedTime;
+};

--- a/src/utils/MeetingOptionCardUtils.ts
+++ b/src/utils/MeetingOptionCardUtils.ts
@@ -1,0 +1,15 @@
+// UI상의 데이터 표시를 위한 데이터 포맷 로직
+export const formatMeetingCardUIData = (type: number, data: string | string[]) => {
+  if (type === 1 && Array.isArray(data)) {
+    return data.join(", ");
+  } else if (type === 3 && typeof data === "string" && data.includes("T")) {
+    const [date, time] = data.split("T");
+    return `${date} ${time}`;
+  } else if (type === 4) {
+    if (!data) return;
+    const index = data.indexOf(" ");
+    return data.slice(index);
+  } else {
+    return data;
+  }
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

#208 

## 📝작업 내용

* 상수 데이터들을 별개의 파일 MeetingCreation.constants.tsx 파일로 분리
* 자잘한 오류들 수정
   * 미팅 생성 페이지에서 하나의 카드가 열리면 다른 카드들은 닫히도록 수정
   * TimePicker 컴포넌트의 hour의 초기값을 배열의 중간값으로 설정
   * 미팅 진행 시간의 범위를 제한
   * 미팅 후보날짜 중 가장 이른 날짜 이후의 날짜들은 투표 마감날짜로 선택이 불가능하도록 제한

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
