### PR TITLE
fix : [KAN-31] 오늘날짜의 이전날짜들 disabling과 미팅후보날짜 이후 날짜들을 투표마감시간 선택에서 disabling 하는것을 모두 만족하도록 수정

### DIFF
--- a/src/pages/meeting/create/MeetingOptionCard.tsx
+++ b/src/pages/meeting/create/MeetingOptionCard.tsx
@@ -33,29 +33,17 @@ const MeetingOptionCard = ({
   const contentRef = useRef<HTMLDivElement>(null); // 사용자 입력 컴포넌트 크기 영역 참조 변수
   let inputComponent = null; // 사용자 입력 방식에 따른 컴포넌트(input태그, 달력, ...)
 
-  const isPreviousDate = (date: Date) => {
-    return date.getTime() < new Date().getTime() && date.getDate() < new Date().getDate();
-  };
-
   switch (type) {
     case 0:
-      inputComponent = (
-        <TextInputComponent
-          dataSetter={
-            dataSetter as React.Dispatch<React.SetStateAction<string>>
-          }
-        />
-      );
+      inputComponent = <TextInputComponent dataSetter={dataSetter as React.Dispatch<React.SetStateAction<string>>} />;
       break;
     case 1:
       inputComponent = (
         <CalendarMultipleInputComponent
-          dataSetter={
-            dataSetter as React.Dispatch<React.SetStateAction<string[]>>
-          }
-          tileDisabled={({ date }) => {
-            return isPreviousDate(date);
-          }}
+          dataSetter={dataSetter as React.Dispatch<React.SetStateAction<string[]>>}
+          // tileDisabled={({ date }) => {
+          //   return isPreviousDate(date);
+          // }}
         />
       );
       break;
@@ -75,33 +63,29 @@ const MeetingOptionCard = ({
       inputComponent = (
         <>
           <CalendarInputComponent
-            dataSetter={
-              dataSetter as React.Dispatch<React.SetStateAction<string>>
-            }
-            tileDisabled={({ date }) => {
-              return isPreviousDate(date);
-            }}
+            dataSetter={dataSetter as React.Dispatch<React.SetStateAction<string>>}
+            // tileDisabled={({ date }) => {
+            //   return isPreviousDate(date);
+            // }}
             meetingCandidateDates={meetingCandidateDates}
           />
           <TimePicker
             onChange={(item) => {
-              (dataSetter as React.Dispatch<React.SetStateAction<string>>)(
-                (prev) => {
-                  if (!prev) {
-                    // 초기의 빈 문자열인 경우
-                    return item;
-                  } else if (prev.includes("T")) {
-                    // 날짜+시간이 이미 입력된 경우
-                    return `${prev?.split("T")[0]}T${item}`;
-                  } else if (prev.includes(":")) {
-                    // 시간만 입력된 경우
-                    return item;
-                  } else {
-                    // 날짜만 입력된 경우
-                    return `${prev}T${item}`;
-                  }
+              (dataSetter as React.Dispatch<React.SetStateAction<string>>)((prev) => {
+                if (!prev) {
+                  // 초기의 빈 문자열인 경우
+                  return item;
+                } else if (prev.includes("T")) {
+                  // 날짜+시간이 이미 입력된 경우
+                  return `${prev?.split("T")[0]}T${item}`;
+                } else if (prev.includes(":")) {
+                  // 시간만 입력된 경우
+                  return item;
+                } else {
+                  // 날짜만 입력된 경우
+                  return `${prev}T${item}`;
                 }
-              );
+              });
             }}
             ampm={false}
             minRange={1}
@@ -112,11 +96,7 @@ const MeetingOptionCard = ({
       break;
     case 4:
       inputComponent = (
-        <ProjectInputComponent
-          dataSetter={
-            dataSetter as React.Dispatch<React.SetStateAction<string>>
-          }
-        />
+        <ProjectInputComponent dataSetter={dataSetter as React.Dispatch<React.SetStateAction<string>>} />
       );
   }
 

--- a/src/pages/meeting/create/input_component/CalendarInputComponent.tsx
+++ b/src/pages/meeting/create/input_component/CalendarInputComponent.tsx
@@ -1,15 +1,15 @@
-import { useEffect, useState, type ComponentProps } from "react";
+import { useEffect, useMemo, useState, type ComponentProps } from "react";
 import Calendar from "react-calendar";
 import "./CalendarInputComponent.scss";
 import { dateFormatter } from "@/utils/dateFormatter";
 import { min, startOfDay } from "date-fns";
+import { isPreviousDate } from "@/utils/MeetingOptionCardUtils";
 
-interface Props extends Omit<ComponentProps<typeof Calendar>, "onClickDay" | "tileClassName" | "formatDay" > {
-  dataSetter:
-    | React.Dispatch<React.SetStateAction<string>>
-    | React.Dispatch<React.SetStateAction<string[]>>;
+interface Props {
+  dataSetter: React.Dispatch<React.SetStateAction<string>> | React.Dispatch<React.SetStateAction<string[]>>;
+  meetingCandidateDates: string[];
 }
-const CalendarInputComponent = ({ dataSetter,...restProps }: Props) => {
+const CalendarInputComponent = ({ dataSetter, meetingCandidateDates }: Props) => {
   const [clickedDay, setClickedDay] = useState<string>();
   const limitDay = useMemo(() => {
     if (!meetingCandidateDates?.length) return undefined;
@@ -47,8 +47,7 @@ const CalendarInputComponent = ({ dataSetter,...restProps }: Props) => {
             return "custom-active";
           }
         }}
-        {...restProps}
-        tileDisabled={({ date, view }) => view === "month" && startOfDay(date) >= limitDay}
+        tileDisabled={({ date, view }) => (view === "month" && startOfDay(date) >= limitDay) || isPreviousDate(date)}
       />
     </div>
   );

--- a/src/pages/meeting/create/input_component/CalendarMultipleInputComponent.tsx
+++ b/src/pages/meeting/create/input_component/CalendarMultipleInputComponent.tsx
@@ -2,13 +2,12 @@ import { useEffect, useState, type ComponentProps } from "react";
 import Calendar from "react-calendar";
 import "./CalendarMultipleInputComponent.scss";
 import { dateFormatter } from "@/utils/dateFormatter";
+import { isPreviousDate } from "@/utils/MeetingOptionCardUtils";
 
-interface Props extends Omit<ComponentProps<typeof Calendar>, "onClickDay" | "tileClassName" | "formatDay" > {
-  dataSetter:
-    | React.Dispatch<React.SetStateAction<string>>
-    | React.Dispatch<React.SetStateAction<string[]>>;
+interface Props extends Omit<ComponentProps<typeof Calendar>, "onClickDay" | "tileClassName" | "formatDay"> {
+  dataSetter: React.Dispatch<React.SetStateAction<string>> | React.Dispatch<React.SetStateAction<string[]>>;
 }
-const CalendarMultipleInputComponent = ({ dataSetter,...restProps }: Props) => {
+const CalendarMultipleInputComponent = ({ dataSetter, ...restProps }: Props) => {
   const [clickedDays, setClickedDays] = useState<string[]>([]);
 
   const clickDaySaver = (value: Date) => {
@@ -34,7 +33,8 @@ const CalendarMultipleInputComponent = ({ dataSetter,...restProps }: Props) => {
             return "custom-active";
           }
         }}
-        {...restProps}
+        // {...restProps}
+        tileDisabled={({ date }) => isPreviousDate(date)}
       />
     </div>
   );

--- a/src/utils/MeetingOptionCardUtils.ts
+++ b/src/utils/MeetingOptionCardUtils.ts
@@ -13,3 +13,7 @@ export const formatMeetingCardUIData = (type: number, data: string | string[]) =
     return data;
   }
 };
+
+export const isPreviousDate = (date: Date) => {
+  return date.getTime() < new Date().getTime() && date.getDate() < new Date().getDate();
+};


### PR DESCRIPTION
…동시에 만족하기

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

* 윤상님이 올린 pr에서 오늘 이전의 날짜들을 disabling 하는 기능과, 제가 수정한 부분인 투표마감시간에서 미팅후보날짜 이후의 날짜들을 disabling 하는 기능을 합쳐서 수정했습니다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
