### PR TITLE
fix : [KAN-85] UI 수정

### DIFF
--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -99,3 +99,13 @@ input:focus {
   pointer-events: auto !important;
   // pointer-events: auto !important;
 }
+
+.eventToast {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}

--- a/src/components/Header.module.scss
+++ b/src/components/Header.module.scss
@@ -14,6 +14,8 @@
     position: absolute;
     left: 20px;
     color: $color-orange-5;
+
+    cursor: pointer;
   }
 
   &__mainlogo {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,15 +12,8 @@ const Header = ({ prevButton }: Props) => {
 
   return (
     <div className={styles.header}>
-      {prevButton && (
-        <LeftArrow className={styles.header__leftArrow} onClick={() => navigate(-1)} />
-      )}
-      <img
-        className={styles.header__mainlogo}
-        src={MainLogo}
-        alt="Meetcha 로고 이미지"
-        onClick={() => navigate("/")}
-      />
+      {prevButton && <LeftArrow className={styles.header__leftArrow} onClick={() => navigate(-1)} />}
+      <img className={styles.header__mainlogo} src={MainLogo} alt="Meetcha 로고 이미지" onClick={() => navigate("/")} />
     </div>
   );
 };

--- a/src/pages/meeting/list/MeetingItemCard.module.scss
+++ b/src/pages/meeting/list/MeetingItemCard.module.scss
@@ -13,6 +13,8 @@
 
   font-family: Pretendard;
 
+  cursor: pointer;
+
   &__leftEdge {
     width: 8px;
     height: 100%;

--- a/src/pages/schedule/monthly_schedule/Calendar.scss
+++ b/src/pages/schedule/monthly_schedule/Calendar.scss
@@ -118,7 +118,7 @@
 
 .monthlyScheduleView .react-calendar__tile {
   max-width: 100%;
-  padding: 10px 6.6667px;
+  padding: 5px 6.6667px;
   background: none;
   text-align: center;
   font: inherit;
@@ -181,17 +181,14 @@
 .monthlyScheduleView .eventTagBox {
   width: 100%;
   height: 100%;
-  display: flex;
-  flex-direction: column;
-
-  gap: 3px;
 }
 
 .monthlyScheduleView .eventTag {
   width: 100%;
-  line-height: 24px;
+  height: 15px;
 
   padding: 0 5px;
+  margin-top: 3px;
 
   border-radius: 15px;
 

--- a/src/pages/schedule/monthly_schedule/EventTagBox.tsx
+++ b/src/pages/schedule/monthly_schedule/EventTagBox.tsx
@@ -6,52 +6,64 @@ interface Props {
 
 const EventTagBox = ({ eventName }: Props) => {
   return (
-    <div className="eventTagBox">
-      {eventName.map((item, index) => (
-        <div
-          key={index}
-          className="eventTag"
-          title={item}
-          onClick={() => {
-            // 바깥 클릭을 한 번만 듣기 위한 핸들러 참조
-            let clickAwayHandler: (e: MouseEvent) => void;
+    <div
+      className="eventTagBox"
+      onClick={() => {
+        // 바깥 클릭을 한 번만 듣기 위한 핸들러 참조
+        let clickAwayHandler: (e: MouseEvent) => void;
 
-            // 토스트를 띄우고 해당 토스트의 id를 받아둠
-            const id = toast.success(item, {
-              containerId: "clickClose",
-              autoClose: false,
-              closeOnClick: false,
+        // 토스트를 띄우고 해당 토스트의 id를 받아둠
+        const id = toast(
+          <div className="eventToast">
+            {eventName.map((val, idx) => {
+              return <div key={idx}>{val}</div>;
+            })}
+          </div>,
+          {
+            containerId: "clickClose",
+            autoClose: false,
+            closeOnClick: false,
 
-              // 열릴 때 문서 클릭(캡처 단계) 한 번만 감시
-              onOpen: () => {
-                clickAwayHandler = (e: MouseEvent) => {
-                  const el = e.target as HTMLElement;
-                  // 토스트 내부 클릭이면 무시
-                  if (el.closest(".Toastify__toast")) return;
+            // 열릴 때 문서 클릭(캡처 단계) 한 번만 감시
+            onOpen: () => {
+              clickAwayHandler = (e: MouseEvent) => {
+                const el = e.target as HTMLElement;
+                // 토스트 내부 클릭이면 무시
+                if (el.closest(".Toastify__toast")) return;
 
-                  // 바깥 클릭이면 닫고 리스너 해제
-                  toast.dismiss(id);
-                  document.removeEventListener("click", clickAwayHandler, true);
-                };
+                // 바깥 클릭이면 닫고 리스너 해제
+                toast.dismiss(id);
+                document.removeEventListener("click", clickAwayHandler, true);
+              };
 
-                // 현재 클릭 이벤트(토스트를 연 클릭)에 바로 걸리지 않도록 지연
-                setTimeout(() => {
-                  document.addEventListener("click", clickAwayHandler, { capture: true });
-                }, 0);
-              },
+              // 현재 클릭 이벤트(토스트를 연 클릭)에 바로 걸리지 않도록 지연
+              setTimeout(() => {
+                document.addEventListener("click", clickAwayHandler, { capture: true });
+              }, 0);
+            },
 
-              // 혹시 다른 방식으로 닫혀도 리스너 정리
-              onClose: () => {
-                if (clickAwayHandler) {
-                  document.removeEventListener("click", clickAwayHandler, true);
-                }
-              },
-            });
-          }}
-        >
-          {item}
-        </div>
-      ))}
+            // 혹시 다른 방식으로 닫혀도 리스너 정리
+            onClose: () => {
+              if (clickAwayHandler) {
+                document.removeEventListener("click", clickAwayHandler, true);
+              }
+            },
+          }
+        );
+      }}
+    >
+      {eventName.map((item, index) => {
+        if (index === 2) {
+          return <div className="eventTag">...</div>;
+        } else if (index > 2) {
+          return null;
+        }
+        return (
+          <div key={index} className="eventTag" title={item}>
+            {item}
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/src/pages/schedule/monthly_schedule/MonthlyScheduleView.tsx
+++ b/src/pages/schedule/monthly_schedule/MonthlyScheduleView.tsx
@@ -30,11 +30,11 @@ const MonthlyScheduleView = ({ schedules, setFetchStandardDate }: Props) => {
             });
           return <EventTagBox eventName={eventName} />;
         }}
-        formatDay={(locale, date) => {
+        formatDay={(_, date) => {
           // console.log(date);
           return date.toLocaleString("en", { day: "numeric" });
         }}
-        formatShortWeekday={(locale, date) => date.toLocaleString("en-US", { weekday: "short" })}
+        formatShortWeekday={(_, date) => date.toLocaleString("en-US", { weekday: "short" })}
         onActiveStartDateChange={({ activeStartDate, view }) => {
           setFetchStandardDate((prev) => {
             const newStandardDate = `${getYear(activeStartDate)} ${getMonth(activeStartDate) + 1}`;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

* 월별 캘린더 페이지에서 일정이 3개 이상인 경우, 2개 + "..."으로 표시되고, 클릭 시 토스트로 모든 일정을 확인할 수 있도록 수정
* 포인터 커서 처리 안되어 있던것들 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
