### PR TITLE
refactor: ui logic을 폼 데이터 관리 로직과 분리 DO NOT MERGE

### DIFF
--- a/src/pages/meeting/create/MeetingCreationView.module.scss
+++ b/src/pages/meeting/create/MeetingCreationView.module.scss
@@ -46,3 +46,105 @@ input {
     color: #b9b9b9;
   }
 }
+
+.accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+  &__item {
+    border-radius: 8px;
+    border: 1px solid $color-gray-8;
+    background: #fff;
+    width: 100%;
+    transition: border-color 300ms cubic-bezier(0.87, 0, 0.13, 1);
+    
+    &[data-state="open"] {
+      border-color: $color-orange-5;
+    }
+  }
+  &__trigger {
+    width: 100%;
+    height: 4rem;
+    display: flex;
+    gap: 16px;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 12px 16px;
+    &[data-state="open"] {
+      border-bottom: 1px solid $color-gray-8;
+    }
+    &__icon {
+      color: $color-orange-1;
+    }
+    &__content {
+      display: flex;
+      gap: 3px;
+      flex-direction: column;
+      align-items: flex-start;
+      flex-grow: 1;
+      &__title {
+        color: $color-gray-2;
+        /* subtitle */
+        font-family: Pretendard;
+        font-size: 14px;
+        font-style: normal;
+        font-weight: 500;
+        line-height: normal;
+      }
+      &__value {
+        color: $color-gray-10;
+        /* title */
+        font-family: Pretendard;
+        font-size: 17px;
+        font-style: normal;
+        font-weight: 600;
+        line-height: 23.1px;
+        /* 135.882% */
+        letter-spacing: 0.17px;
+      }
+    }
+    &__chevron {
+      transition: transform 300ms cubic-bezier(0.87, 0, 0.13, 1);
+      color: $color-gray-2;
+    }
+
+    &[data-state="open"] &__chevron {
+      transform: rotate(180deg);
+    }
+  }
+  
+  &__content {
+    overflow: hidden;
+    
+    &[data-state="open"] {
+      animation: slideDown 300ms cubic-bezier(0.87, 0, 0.13, 1);
+    }
+    
+    &[data-state="closed"] {
+      animation: slideUp 300ms cubic-bezier(0.87, 0, 0.13, 1);
+    }
+  }
+}
+
+@keyframes slideDown {
+  from {
+    height: 0;
+    opacity: 0;
+  }
+  to {
+    height: var(--radix-accordion-content-height);
+    opacity: 1;
+  }
+}
+
+@keyframes slideUp {
+  from {
+    height: var(--radix-accordion-content-height);
+    opacity: 1;
+  }
+  to {
+    height: 0;
+    opacity: 0;
+  }
+}

--- a/src/pages/meeting/create/MeetingCreationView.tsx
+++ b/src/pages/meeting/create/MeetingCreationView.tsx
@@ -1,45 +1,69 @@
-import React, { useEffect, useState } from "react";
+import React, { useRef } from "react";
 import styles from "./MeetingCreationView.module.scss";
 import MeetingOptionCard from "./MeetingOptionCard";
 import type { MeetingSendData } from "./MeetingCreationPage";
 import { cardDataSet } from "./constants/MeetingCreation.constants";
-import { deadlineParse, durationMinutesParse, projectDataParse } from "@/utils/MeetingCreationUtils";
+import {
+  useMeetingCreateFormContext,
+} from "./hooks/useMeetingCreateForm";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionHeader,
+  AccordionItem,
+  AccordionTrigger,
+} from "@radix-ui/react-accordion";
+import Pencil from "@assets/pencil.svg?react";
+import DownArrow from "@assets/downArrow.svg?react";
+import Calendar from "@assets/calendar.svg?react";
+import TextInputComponent from "./input_component/TextInputComponent";
+import type { MeetingCreationSchema } from "./schemas/meetingCreationSchema";
 
 interface Props {
   setAllDataReserved: React.Dispatch<React.SetStateAction<boolean>>;
   setCompleteData: React.Dispatch<React.SetStateAction<MeetingSendData>>;
 }
 
-const MeetingCreationView = ({ setAllDataReserved, setCompleteData }: Props) => {
-  const [meetingTitle, setMeetingTitle] = useState<string>("");
-  const [meetingDescription, setMeetingDescription] = useState<string>("");
-  const [meetingCandidateDates, setMeetingCandidateDates] = useState<string[]>([]);
-  const [durationMinutes, setDurationMinutes] = useState<string>("");
-  const [deadline, setDeadline] = useState<string>("");
-  const [projectData, setProjectData] = useState<string>(null);
-  const [clickedCardNum, setClickedCardNum] = useState<number>(null); // 미팅 카드 중 유저가 클릭한 카드의 번호
+const fieldNames: Record<
+  keyof MeetingCreationSchema,
+  keyof MeetingCreationSchema
+> = {
+  title: "title",
+  description: "description",
+  candidateDates: "candidateDates",
+  durationMinutes: "durationMinutes",
+  deadline: "deadline",
+  projectId: "projectId",
+};
 
-  const stateMapping = {
-    description: { data: meetingDescription, dataSetter: setMeetingDescription },
-    candidateDates: { data: meetingCandidateDates, dataSetter: setMeetingCandidateDates },
-    durationMinutes: { data: durationMinutes, dataSetter: setDurationMinutes },
-    deadline: { data: deadline, dataSetter: setDeadline },
-    project: { data: projectData, dataSetter: setProjectData },
-  };
+const TriggerContent = ({
+  icon,
+  title,
+  value,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  value: string | string[];
+}) => {
+  return (
+    <>
+      {icon}
+      <div className={styles.accordion__trigger__content}>
+        <p className={styles.accordion__trigger__content__title}>{title}</p>
+        <p className={styles.accordion__trigger__content__value}>
+          {typeof value === "string" ? value : value.join(", ")}
+        </p>
+      </div>
+      <DownArrow className={styles.accordion__trigger__chevron} />
+    </>
+  );
+};
 
-  useEffect(() => {
-    if (meetingTitle && meetingCandidateDates.length > 0 && durationMinutes && deadlineParse(deadline)) {
-      setAllDataReserved(true);
-      setCompleteData({
-        title: meetingTitle,
-        description: meetingDescription,
-        candidateDates: meetingCandidateDates,
-        durationMinutes: durationMinutesParse(durationMinutes),
-        deadline: deadlineParse(deadline),
-        projectId: projectDataParse(projectData),
-      });
-    }
-  }, [meetingTitle, meetingDescription, meetingCandidateDates, durationMinutes, deadline, projectData]);
+const MeetingCreationView = ({
+  setAllDataReserved,
+  setCompleteData,
+}: Props) => {
+  const form = useMeetingCreateFormContext();
 
   return (
     <div className={styles.meetingCreationView}>
@@ -48,24 +72,59 @@ const MeetingCreationView = ({ setAllDataReserved, setCompleteData }: Props) => 
         type="text"
         placeholder="미팅 제목을 적어주세요"
         onChange={(e) => {
-          setMeetingTitle(e.target.value);
+          form.setFormValue("title", e.target.value);
         }}
       />
-      <div className={styles.meetingCreationView__meetingOptionContainer}>
-        {cardDataSet.map((item, _) => (
-          <MeetingOptionCard
-            key={item.id}
-            title={item.title}
-            icon={item.icon}
-            data={stateMapping[item.stateKey as keyof typeof stateMapping].data}
-            dataSetter={stateMapping[item.stateKey as keyof typeof stateMapping].dataSetter}
-            type={item.id}
-            clickedCardNum={clickedCardNum}
-            setCardClickedNum={setClickedCardNum}
-            meetingCandidateDates={meetingCandidateDates}
-          />
-        ))}
-      </div>
+      <Accordion
+        type="single"
+        collapsible
+        className={styles.accordion}
+      >
+        <AccordionItem
+          value={fieldNames.description}
+          className={styles.accordion__item}
+        >
+          <AccordionHeader>
+            <AccordionTrigger className={styles.accordion__trigger}>
+              <TriggerContent
+                icon={<Pencil className={styles.accordion__trigger__icon} />}
+                title="미팅 설명"
+                value={form.getFormValue("description") || "-"}
+              />
+            </AccordionTrigger>
+          </AccordionHeader>
+          <AccordionContent className={styles.accordion__content}>
+            <textarea
+              style={{
+                width: "100%",
+                height: "4rem",
+                padding: "5px",
+                border: "none",
+                outline: "none",
+                fontFamily: "Pretendard",
+                resize: "none",
+              }}
+              value={form.getFormValue("description") || ""}
+              onChange={(e) => {
+                form.setFormValue("description", e.target.value);
+              }}
+            />
+          </AccordionContent>
+        </AccordionItem>
+        <AccordionItem
+          value={fieldNames.candidateDates}
+          className={styles.accordion__item}
+        >
+          <AccordionHeader>
+            <AccordionTrigger className={styles.accordion__trigger}>
+              <TriggerContent icon={<Calendar className={styles.accordion__trigger__icon} />} title="미팅 후보 날짜" value={form.getFormValue("candidateDates")} />
+            </AccordionTrigger>
+          </AccordionHeader>
+          <AccordionContent className={styles.accordion__content}>
+            미구현
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
     </div>
   );
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

radix-ui의 아코디온으로 ui 구성
이를 통해 Ui로직을 간략화 할 수 있으며, 컴포짓 패턴으로 ui 뼈대 작성 가능
headless 디자인 시스템이라 스타일 완전 커스텀 가능
이를 통해 하나만 열리게하고 아코디언 열림/닫힘 트리거, 컨텐츠와 트리거 영역을 은닉 가능했음
이건 폼 필드 하나 적용한 예시입니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
