### PR TITLE
fix: [KAN-88] view에 따라 현재 날짜 미만인 타일만 disable되도록 수정

### DIFF
--- a/src/pages/meeting/create/input_component/DateTimePicker.tsx
+++ b/src/pages/meeting/create/input_component/DateTimePicker.tsx
@@ -69,13 +69,13 @@ export const DateTimePicker = () => {
               return "custom-active";
             }
           }}
-          tileDisabled={({ date }) => {
+          tileDisabled={({ date, view }) => {
             const candidateDates = form.getFormValue("candidateDates");
             const minDate =
               candidateDates.length > 0 ? dayjs.min(candidateDates.map((d) => dayjs(d))) : null;
 
             return (
-              isPreviousDate(date) ||
+              isPreviousDate(date, view) ||
               (minDate && dayjs(date).isAfter(minDate, "day")) ||
               candidateDates.includes(formatDate(date))
             );

--- a/src/pages/meeting/create/input_component/MultiSelectCalendar.scss
+++ b/src/pages/meeting/create/input_component/MultiSelectCalendar.scss
@@ -120,8 +120,9 @@
 }
 
 .calendarMultipleInputComponent .react-calendar__tile:disabled {
-  background-color: #f0f0f0;
-  color: #ababab;
+  background-color: #f5f5f5;
+  color: #b3b3b3;
+  cursor: not-allowed;
 }
 
 .calendarMultipleInputComponent .react-calendar__month-view__days__day--neighboringMonth:disabled,
@@ -132,7 +133,7 @@
 
 .calendarMultipleInputComponent .react-calendar__tile:enabled:hover,
 .calendarMultipleInputComponent .react-calendar__tile:enabled:focus {
-  background-color: #e6e6e6;
+  background-color: #fff6e6;
 }
 
 .calendarMultipleInputComponent .react-calendar__tile--now {

--- a/src/pages/meeting/create/input_component/MultiSelectCalendar.tsx
+++ b/src/pages/meeting/create/input_component/MultiSelectCalendar.tsx
@@ -36,9 +36,9 @@ export const MultiSelectCalendar = () => {
             return "custom-active";
           }
         }}
-        tileDisabled={({ date }) => {
+        tileDisabled={({ date, view }) => {
           return (
-            isPreviousDate(date) ||
+            isPreviousDate(date, view) ||
             (form.getFormValue("candidateDates").length >= 10 &&
               !form.getFormValue("candidateDates").includes(formatDate(date)))
           );

--- a/src/pages/schedule/weekly_schedule/WeeklyCalendar.scss
+++ b/src/pages/schedule/weekly_schedule/WeeklyCalendar.scss
@@ -879,8 +879,6 @@ button.rbc-input::-moz-focus-inner {
   width: 141px;
 }
 
-/*# sourceMappingURL=react-big-calendar.css.map */
-
 //
 .rbc-toolbar-label {
   display: none;

--- a/src/utils/MeetingOptionCardUtils.ts
+++ b/src/utils/MeetingOptionCardUtils.ts
@@ -1,3 +1,6 @@
+import type { TileArgs } from "react-calendar";
+import { isBefore, startOfDay, startOfMonth, startOfYear } from "date-fns";
+
 // UI상의 데이터 표시를 위한 데이터 포맷 로직
 export const formatMeetingCardUIData = (type: number, data: string | string[]) => {
   if (type === 1 && Array.isArray(data)) {
@@ -14,6 +17,29 @@ export const formatMeetingCardUIData = (type: number, data: string | string[]) =
   }
 };
 
-export const isPreviousDate = (date: Date) => {
-  return date.getTime() < new Date().getTime() && date.getDate() < new Date().getDate();
+export const isPreviousDate = (date: Date, view: TileArgs["view"] = "month") => {
+  const now = new Date();
+
+  const startOfDecade = (d: Date) => new Date(Math.floor(d.getFullYear() / 10) * 10, 0, 1);
+
+  const normalizeByView = (d: Date) => {
+    switch (view) {
+      case "month":
+        return startOfDay(d);
+      case "year":
+        return startOfMonth(d);
+      case "decade":
+        return startOfYear(d);
+      case "century":
+        // react-calendar century view tiles represent decades
+        return startOfDecade(d);
+      default:
+        return startOfDay(d);
+    }
+  };
+
+  const left = normalizeByView(date);
+  const right = normalizeByView(now);
+  // strictly earlier only; equal returns false per requirements
+  return isBefore(left, right);
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 기존엔 view를 이동하면, 현재 시간대도 disable되며, view가 month(기본)일때 이전 달에서 현재 날짜 이상이면 enable되는 버그 존재
- 개발서버 구동 안되게하는 map 로직 제거
- view에 따라 disable 조건 분기
- view의 하위 단위 (ex view가 month라면 하위단위는 day)에 따라 현재 날짜 이상인 것은 enable, 미만인 것은 disable

### 스크린샷 (선택)
2025 10.31일 기준 
month일땐 2025 10.31부터 선택 가능
year일떈 2025 10월부터 선택 가능

<img width="2824" height="642" alt="image" src="https://github.com/user-attachments/assets/f10598c6-828e-451e-99df-90b9632f90e6" />

<img width="2820" height="558" alt="image" src="https://github.com/user-attachments/assets/352acb27-b116-4e5b-85d9-ead87288b788" />

<img width="2822" height="548" alt="image" src="https://github.com/user-attachments/assets/150b68c5-4725-4b5b-ae08-9ebfd0ee581a" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

함수내에서 new Date로 현재 날짜를 얻어오는데, 이걸 외부에서 받도록 해야할지 고민
