### PR TITLE
fix: 리프레시 토큰 재발급 로직 변경

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,9 +1,4 @@
 {
-  "src/apis/apiCall.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 2
-    }
-  },
   "src/apis/meeting/meetingAPI.ts": {
     "@typescript-eslint/no-unused-vars": {
       "count": 1

--- a/src/apis/apiCall.ts
+++ b/src/apis/apiCall.ts
@@ -1,19 +1,37 @@
-import { renewAccessToken } from "./auth/authAPI";
 import type { ApiResponse } from "./common/types";
 
 export const API_BASE = import.meta.env.VITE_API_BASE_URL;
 
+const tokenRefresh = async (refreshToken: string) => {
+  return fetch(`${API_BASE}/oauth/refresh`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ refreshToken }),
+  })
+    .then((res) => res.json())
+    .then((res) => {
+      localStorage.setItem("access-token", res.data.accessToken);
+      localStorage.setItem("refresh-token", res.data.refreshToken);
+    })
+    .catch((e) => {
+      throw e;
+    });
+};
+
+const RETRY_LIMIT = 2;
 export const apiCall = async <T>(
   path: string,
   method = "GET",
-  data?: any,
+  data?: unknown,
   withAuth = false
 ): Promise<ApiResponse<T>> => {
-  const access_token = localStorage.getItem("access-token");
-  const refresh_token = localStorage.getItem("refresh-token");
+  let SAFE_RETRY_FLAG = 0;
 
-  const doFetch = () =>
-    fetch(`${API_BASE}${path}`, {
+  const doFetch = () => {
+    const access_token = localStorage.getItem("access-token");
+    return fetch(`${API_BASE}${path}`, {
       method,
       headers: {
         "Content-Type": "application/json",
@@ -21,33 +39,32 @@ export const apiCall = async <T>(
       },
       ...(data && { body: JSON.stringify(data) }),
     });
-
-  try {
-    let res = await doFetch();
-
-    if (res.ok) {
-      console.log(`Api Call Success: ${res.status} ${res.statusText}`);
-    } else {
-      console.error(`Api Call Failed: ${res.status} ${res.statusText}`);
-    }
-
-    if (res.status === 401 && !path.includes("/oauth/refresh")) {
-      if (refresh_token && (await renewAccessToken(refresh_token))) {
-        res = await doFetch();
-        if (res.ok) {
-          console.log(`Api Call Success (after refresh): ${res.status} ${res.statusText}`);
-          return res.json();
+  };
+  return doFetch()
+    .then((res) => {
+      SAFE_RETRY_FLAG++;
+      return res;
+    })
+    .then(async (res) => {
+      // TODO: 매우 중요, 아직도 500 에러가 나옴
+      // TODO: Bearer sdlksdfnk 같이 임의 작성이나, Bearer null같이 access token이 없는 경우 500에러
+      if (res.status === 401 || res.status === 500) {
+        const refresh_token = localStorage.getItem("refresh-token");
+        if (refresh_token && SAFE_RETRY_FLAG < RETRY_LIMIT) {
+          return tokenRefresh(refresh_token).then(() => doFetch());
+        } else {
+          throw new Error("Error, retry limit exceeded or refresh token not found");
         }
+      } else {
+        return res;
       }
-      console.error("Unauthorized: token refresh failed or retry failed.");
+    })
+    .then((res) => res.json())
+    .catch((e) => {
       localStorage.removeItem("access-token");
       localStorage.removeItem("refresh-token");
+      // TODO: 책임 이관 필요
       window.location.href = "/";
-    }
-
-    return res.json();
-  } catch (e: any) {
-    console.error(e.message);
-    throw e;
-  }
+      throw e;
+    });
 };

--- a/src/apis/auth/authAPI.ts
+++ b/src/apis/auth/authAPI.ts
@@ -11,19 +11,6 @@ export const sendAuthCode = async (authCode: string, addr: string) => {
   return res;
 };
 
-export const renewAccessToken = async (refToken: string) => {
-  const data = { refreshToken: refToken };
-  const res: ApiResponse<AuthResponse> = await apiCall("/oauth/refresh", "POST", data, false);
-  if (res.code === 200) {
-    console.log(res.message);
-    localStorage.setItem("access-token", res.data.accessToken);
-    localStorage.setItem("refresh-token", res.data.refreshToken);
-    return true;
-  } else {
-    return false;
-  }
-};
-
 export const logout = async () => {
   const res: ApiResponse<logoutResponse> = await apiCall("/oauth/logout", "POST", null, true);
   const type = getResponseType(res.code);


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- promise chaining을 통해 선언적으로 로직 작성
- 현재 시점으로 401이 아니라 500이 나와서 500일때도 재발급
- 무한루프 보호(재시도 횟수 최대 2번)
- 리프레시 토큰은 api 클라이언트를 따로 분리

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
