### PR TITLE
feat: [KAN-221] 미팅 실패시 참가 내역 확인 가능

### DIFF
--- a/src/apis/meeting/meetingAPI.ts
+++ b/src/apis/meeting/meetingAPI.ts
@@ -6,6 +6,7 @@ import type {
   Meeting,
   MeetingCreateResponse,
   MeetingDetail,
+  MeetingAvailabilities,
 } from "./meetingTypes";
 
 export const fetchMeetingList = async () => {
@@ -74,5 +75,15 @@ export const deleteMeeting = async (meetingId: string) => {
     // 상위에서 잡을 수 있도록 에러 던짐
     throw new Error(res.message);
   }
+  return res;
+};
+
+export const fetchMeetingAvailabilities = async (meetingId: string) => {
+  const res: ApiResponse<MeetingAvailabilities> = await apiCall(
+    `/meeting-lists/${meetingId}/availabilities`,
+    "GET",
+    null,
+    true
+  );
   return res;
 };

--- a/src/apis/meeting/meetingTypes.ts
+++ b/src/apis/meeting/meetingTypes.ts
@@ -61,3 +61,30 @@ export interface DeleteRes {
   meetingId: string;
   message: string;
 }
+
+export interface MeetingAvailabilities {
+  participants: AvailabilityParticipant[];
+  /**
+   * 총 참여자 수
+   */
+  count: number;
+}
+
+export interface AvailabilityParticipant {
+  participantId: string;
+  userId: string;
+  name: string;
+  availabilities: Availability[];
+}
+
+export interface Availability {
+  availabilityId: string;
+  /**
+   * format: 2025-07-22T16:00:00
+   */
+  startAt: string;
+  /**
+   * format: 2025-07-22T16:00:00
+   */
+  endAt: string;
+}

--- a/src/mocks/data/meetingAvailabilities.ts
+++ b/src/mocks/data/meetingAvailabilities.ts
@@ -1,0 +1,208 @@
+import type { MeetingAvailabilities } from "@/apis/meeting/meetingTypes";
+
+export const meetingAvailabilitiesMock: MeetingAvailabilities = {
+  participants: [
+    {
+      // 1번: 월 화 수 목 금 토 (일 제외)
+      participantId: "participant-1",
+      userId: "user-1",
+      name: "참여자1",
+      availabilities: [
+        {
+          availabilityId: "avail-1-1",
+          startAt: "2025-12-22T18:00:00",
+          endAt: "2025-12-22T21:00:00",
+        }, // 월
+        {
+          availabilityId: "avail-1-2",
+          startAt: "2025-12-23T18:00:00",
+          endAt: "2025-12-23T21:00:00",
+        }, // 화
+        {
+          availabilityId: "avail-1-3",
+          startAt: "2025-12-24T18:00:00",
+          endAt: "2025-12-24T21:00:00",
+        }, // 수
+        {
+          availabilityId: "avail-1-4",
+          startAt: "2025-12-25T18:00:00",
+          endAt: "2025-12-25T21:00:00",
+        }, // 목
+        {
+          availabilityId: "avail-1-5",
+          startAt: "2025-12-26T18:00:00",
+          endAt: "2025-12-26T21:00:00",
+        }, // 금
+        {
+          availabilityId: "avail-1-6",
+          startAt: "2025-12-27T18:00:00",
+          endAt: "2025-12-27T21:00:00",
+        }, // 토
+      ],
+    },
+    {
+      // 2번: 화 수 목 금 토 (일, 월 제외)
+      participantId: "participant-2",
+      userId: "user-2",
+      name: "참여자2",
+      availabilities: [
+        {
+          availabilityId: "avail-2-1",
+          startAt: "2025-12-23T18:00:00",
+          endAt: "2025-12-23T21:00:00",
+        }, // 화
+        {
+          availabilityId: "avail-2-2",
+          startAt: "2025-12-24T18:00:00",
+          endAt: "2025-12-24T21:00:00",
+        }, // 수
+        {
+          availabilityId: "avail-2-3",
+          startAt: "2025-12-25T18:00:00",
+          endAt: "2025-12-25T21:00:00",
+        }, // 목
+        {
+          availabilityId: "avail-2-4",
+          startAt: "2025-12-26T18:00:00",
+          endAt: "2025-12-26T21:00:00",
+        }, // 금
+        {
+          availabilityId: "avail-2-5-1",
+          startAt: "2025-12-27T18:00:00",
+          endAt: "2025-12-27T18:30:00",
+        }, // 토 30분
+        {
+          availabilityId: "avail-2-5-2",
+          startAt: "2025-12-27T18:30:00",
+          endAt: "2025-12-27T19:00:00",
+        }, // 토 30분
+        {
+          availabilityId: "avail-2-5-3",
+          startAt: "2025-12-27T19:00:00",
+          endAt: "2025-12-27T19:30:00",
+        }, // 토 30분
+        {
+          availabilityId: "avail-2-5-4",
+          startAt: "2025-12-27T19:30:00",
+          endAt: "2025-12-27T20:00:00",
+        }, // 토 30분
+        {
+          availabilityId: "avail-2-5-5",
+          startAt: "2025-12-27T20:00:00",
+          endAt: "2025-12-27T20:30:00",
+        }, // 토 30분
+        {
+          availabilityId: "avail-2-5-6",
+          startAt: "2025-12-27T20:30:00",
+          endAt: "2025-12-27T21:00:00",
+        }, // 토 30분
+      ],
+    },
+    {
+      // 3번: 수 목 금 토 (일, 월, 화 제외)
+      participantId: "participant-3",
+      userId: "user-3",
+      name: "참여자3",
+      availabilities: [
+        {
+          availabilityId: "avail-3-1",
+          startAt: "2025-12-24T18:00:00",
+          endAt: "2025-12-24T21:00:00",
+        }, // 수
+        {
+          availabilityId: "avail-3-2",
+          startAt: "2025-12-25T18:00:00",
+          endAt: "2025-12-25T21:00:00",
+        }, // 목
+        {
+          availabilityId: "avail-3-3",
+          startAt: "2025-12-26T18:00:00",
+          endAt: "2025-12-26T21:00:00",
+        }, // 금
+        {
+          availabilityId: "avail-3-4-1",
+          startAt: "2025-12-27T18:00:00",
+          endAt: "2025-12-27T19:00:00",
+        }, // 토 1시간
+        {
+          availabilityId: "avail-3-4-2",
+          startAt: "2025-12-27T19:00:00",
+          endAt: "2025-12-27T20:00:00",
+        }, // 토 1시간
+        {
+          availabilityId: "avail-3-4-3",
+          startAt: "2025-12-27T20:00:00",
+          endAt: "2025-12-27T21:00:00",
+        }, // 토 1시간
+      ],
+    },
+    {
+      // 4번: 목 금 토 (일, 월, 화, 수 제외)
+      participantId: "participant-4",
+      userId: "user-4",
+      name: "참여자4",
+      availabilities: [
+        {
+          availabilityId: "avail-4-1",
+          startAt: "2025-12-25T18:00:00",
+          endAt: "2025-12-25T21:00:00",
+        }, // 목
+        {
+          availabilityId: "avail-4-2",
+          startAt: "2025-12-26T18:00:00",
+          endAt: "2025-12-26T21:00:00",
+        }, // 금
+        {
+          availabilityId: "avail-4-3",
+          startAt: "2025-12-27T18:00:00",
+          endAt: "2025-12-27T21:00:00",
+        }, // 토
+      ],
+    },
+    {
+      // 5번: 금 토 (일, 월, 화, 수, 목 제외)
+      participantId: "participant-5",
+      userId: "user-5",
+      name: "참여자5",
+      availabilities: [
+        {
+          availabilityId: "avail-5-1",
+          startAt: "2025-12-26T18:00:00",
+          endAt: "2025-12-26T21:00:00",
+        }, // 금
+        {
+          availabilityId: "avail-5-2",
+          startAt: "2025-12-27T18:00:00",
+          endAt: "2025-12-27T21:00:00",
+        }, // 토
+      ],
+    },
+    {
+      // 6번: 토 (일, 월, 화, 수, 목, 금 제외)
+      participantId: "participant-6",
+      userId: "user-6",
+      name: "참여자6",
+      availabilities: [
+        {
+          availabilityId: "avail-6-1",
+          startAt: "2025-12-27T18:00:00",
+          endAt: "2025-12-27T21:00:00",
+        }, // 토
+      ],
+    },
+    {
+      // 7번: 월 (일, 화, 수, 목, 금, 토 제외)
+      participantId: "participant-7",
+      userId: "user-7",
+      name: "참여자7",
+      availabilities: [
+        {
+          availabilityId: "avail-7-1",
+          startAt: "2025-12-22T18:00:00",
+          endAt: "2025-12-22T21:00:00",
+        }, // 월
+      ],
+    },
+  ],
+  count: 7,
+};

--- a/src/mocks/data/meetingAvailabilities.ts
+++ b/src/mocks/data/meetingAvailabilities.ts
@@ -198,8 +198,8 @@ export const meetingAvailabilitiesMock: MeetingAvailabilities = {
       availabilities: [
         {
           availabilityId: "avail-7-1",
-          startAt: "2025-12-22T18:00:00",
-          endAt: "2025-12-22T21:00:00",
+          startAt: "2025-12-21T18:00:00",
+          endAt: "2025-12-21T21:00:00",
         }, // 월
       ],
     },

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,2 +1,19 @@
-import { RequestHandler, WebSocketHandler } from "msw";
-export const handlers: Array<RequestHandler | WebSocketHandler> = [];
+import { RequestHandler, WebSocketHandler, http, HttpResponse } from "msw";
+import { meetingAvailabilitiesMock } from "../data/meetingAvailabilities";
+import type { ApiResponse } from "@/apis/common/types";
+import type { MeetingAvailabilities } from "@/apis/meeting/meetingTypes";
+import { API_BASE } from "@/apis/apiCall";
+
+export const handlers: Array<RequestHandler | WebSocketHandler> = [
+  http.get(`${API_BASE}/meeting-lists/:meetingId/availabilities`, () => {
+    const response: ApiResponse<MeetingAvailabilities> = {
+      timestamp: new Date().toISOString(),
+      path: "/meeting-lists/:meetingId/availabilities",
+      code: 200,
+      message: "Success",
+      data: meetingAvailabilitiesMock,
+    };
+
+    return HttpResponse.json(response);
+  }),
+];

--- a/src/pages/meeting/detail/MeetingAvailabilities.module.scss
+++ b/src/pages/meeting/detail/MeetingAvailabilities.module.scss
@@ -4,6 +4,9 @@
 .container {
   width: 100%;
   margin-top: 37px;
+  display: flex;
+  flex-direction: column;
+  gap: 13px;
 }
 
 .title {
@@ -65,4 +68,25 @@
   display: flex;
   line-height: 140%;
   justify-content: space-between;
+}
+
+.calendarContainer {
+  width: 100%;
+
+  :global(.fc) {
+    .fc-event {
+      background-color: $color-orange-700;
+      border-color: $color-orange-700;
+      border-radius: 4px;
+    }
+
+    .fc-event-title {
+      display: none;
+    }
+  }
+}
+
+.calendarEvent {
+  background-color: $color-orange-700 !important;
+  border-color: $color-orange-700 !important;
 }

--- a/src/pages/meeting/detail/MeetingAvailabilities.module.scss
+++ b/src/pages/meeting/detail/MeetingAvailabilities.module.scss
@@ -1,0 +1,68 @@
+@import "@/assets/styles/colors";
+@import "@/assets/styles/typography";
+
+.container {
+  width: 100%;
+  margin-top: 37px;
+}
+
+.title {
+  &__main {
+    @include body-2;
+    margin-bottom: 2px;
+  }
+
+  &__sub {
+    @include small-1;
+  }
+  &__inputContainer {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    @include body-2;
+    &__input {
+      &::-webkit-inner-spin-button,
+      &::-webkit-outer-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+      }
+
+      -moz-appearance: textfield;
+      appearance: textfield;
+      text-align: center;
+      padding: 4px 12px;
+      border-radius: 4px;
+      border: 1px solid $color-gray-200;
+    }
+
+    &__iconContainer {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 5px;
+
+      &__icon {
+        height: 16px;
+        width: 16px;
+        &:hover {
+          opacity: 0.8;
+        }
+      }
+
+      &__iconButton {
+        cursor: pointer;
+        padding: 0;
+        color: $color-orange-700;
+        &:disabled {
+          color: $color-gray-400;
+          cursor: not-allowed;
+        }
+      }
+    }
+  }
+
+  color: $color-gray-600;
+  display: flex;
+  line-height: 140%;
+  justify-content: space-between;
+}

--- a/src/pages/meeting/detail/MeetingAvailabilities.tsx
+++ b/src/pages/meeting/detail/MeetingAvailabilities.tsx
@@ -11,6 +11,7 @@ import {
 import FullCalendar from "@fullcalendar/react";
 import timeGridPlugin from "@fullcalendar/timegrid";
 import type { EventInput } from "@fullcalendar/core";
+import { format, parseISO } from "date-fns";
 export const MeetingAvailabilitiesContainer = ({ meetingId }: { meetingId: string }) => {
   const [availabilities, setAvailabilities] = useState<MeetingAvailabilities | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
@@ -65,6 +66,15 @@ const MeetingAvailabilitiesContent = ({
   const [selectedCount, setSelectedCount] = useState<number>(initialCount);
   const isUpperBound = selectedCount >= totalCount;
   const isLowerBound = selectedCount <= 1;
+
+  const minTime = useMemo(() => {
+    const earliest = Array.from(participantsTime.keys())
+      .map((time) => format(parseISO(time), "HH:mm:ss"))
+      .sort()[0];
+    const fallbackTime = "12:00:00";
+    if (!earliest) return fallbackTime;
+    return earliest > fallbackTime ? fallbackTime : earliest;
+  }, [participantsTime]);
 
   const calendarEvents = useMemo<EventInput[]>(() => {
     const filteredTime = filterParticipantsTime(participantsTime, selectedCount);
@@ -139,8 +149,9 @@ const MeetingAvailabilitiesContent = ({
           slotDuration="00:30:00"
           slotMinTime="00:00:00"
           slotMaxTime="24:00:00"
+          scrollTime={minTime}
           allDaySlot={false}
-          height="auto"
+          contentHeight={"calc(1.5em * 24)"}
           headerToolbar={false}
           locale="ko"
         />

--- a/src/pages/meeting/detail/MeetingAvailabilities.tsx
+++ b/src/pages/meeting/detail/MeetingAvailabilities.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+import styles from "./MeetingAvailabilities.module.scss";
+import { fetchMeetingAvailabilities } from "@/apis/meeting/meetingAPI";
+import type { MeetingAvailabilities } from "@/apis/meeting/meetingTypes";
+import { BiChevronDown, BiChevronUp } from "react-icons/bi";
+export const MeetingAvailabilitiesContainer = ({ meetingId }: { meetingId: string }) => {
+  const [availabilities, setAvailabilities] = useState<MeetingAvailabilities | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  useEffect(() => {
+    setLoading(true);
+    fetchMeetingAvailabilities(meetingId)
+      .then((res) => {
+        if (res.code === 200) {
+          setAvailabilities(res.data);
+        } else {
+          setError(res.message);
+        }
+      })
+      .catch((err) => {
+        setError(err.message);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [meetingId]);
+  // TODO: 각 케이스 디자인 시안 요구
+  if (loading) return null;
+  if (error) return null;
+  if (!availabilities) return null;
+  if (availabilities.count === 0) return null;
+
+  return <MeetingAvailabilitiesContent availabilities={availabilities} />;
+};
+
+const MeetingAvailabilitiesContent = ({
+  availabilities,
+}: {
+  availabilities: MeetingAvailabilities;
+}) => {
+  const [selectedCount, setSelectedCount] = useState<number>(1);
+  const isUpperBound = selectedCount >= availabilities.count;
+  const isLowerBound = selectedCount <= 1;
+  return (
+    <div className={styles.container}>
+      <div className={styles.title}>
+        <div>
+          <p className={styles.title__main}>참가 내역</p>
+          <p className={styles.title__sub}>참여 가능 인원을 확인해 보세요</p>
+        </div>
+        <div className={styles.title__inputContainer}>
+          <input
+            type="number"
+            name="count"
+            className={styles.title__inputContainer__input}
+            min={1}
+            max={availabilities.count}
+            value={selectedCount}
+            onChange={(e) => {
+              const numValue = parseInt(e.target.value);
+              if (numValue > availabilities.count) {
+                return;
+              }
+              setSelectedCount(numValue);
+            }}
+          />
+          <div className={styles.title__inputContainer__iconContainer}>
+            <button
+              name="up"
+              disabled={isUpperBound}
+              className={styles.title__inputContainer__iconContainer__iconButton}
+              onClick={() => {
+                if (!isUpperBound) {
+                  setSelectedCount(selectedCount + 1);
+                }
+              }}
+            >
+              <BiChevronUp className={styles.title__inputContainer__iconContainer__icon} />
+            </button>
+            <button
+              name="down"
+              disabled={isLowerBound}
+              className={styles.title__inputContainer__iconContainer__iconButton}
+              onClick={() => {
+                if (!isLowerBound) {
+                  setSelectedCount(selectedCount - 1);
+                }
+              }}
+            >
+              <BiChevronDown className={styles.title__inputContainer__iconContainer__icon} />
+            </button>
+          </div>
+          <p>/ {availabilities.count}</p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/meeting/detail/MeetingAvailabilities.tsx
+++ b/src/pages/meeting/detail/MeetingAvailabilities.tsx
@@ -1,8 +1,16 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import styles from "./MeetingAvailabilities.module.scss";
 import { fetchMeetingAvailabilities } from "@/apis/meeting/meetingAPI";
 import type { MeetingAvailabilities } from "@/apis/meeting/meetingTypes";
 import { BiChevronDown, BiChevronUp } from "react-icons/bi";
+import {
+  filterParticipantsTime,
+  mergeParticipantsTime,
+  splitParticipantsTime,
+} from "@/utils/participantsTime";
+import FullCalendar from "@fullcalendar/react";
+import timeGridPlugin from "@fullcalendar/timegrid";
+import type { EventInput } from "@fullcalendar/core";
 export const MeetingAvailabilitiesContainer = ({ meetingId }: { meetingId: string }) => {
   const [availabilities, setAvailabilities] = useState<MeetingAvailabilities | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
@@ -24,23 +32,51 @@ export const MeetingAvailabilitiesContainer = ({ meetingId }: { meetingId: strin
         setLoading(false);
       });
   }, [meetingId]);
+  const initialCount = useMemo(() => {
+    if (!availabilities) return 1;
+    const participantsTime = splitParticipantsTime(availabilities.participants);
+    const maxCount = Math.max(...participantsTime.values(), 1);
+    return maxCount;
+  }, [availabilities]);
   // TODO: 각 케이스 디자인 시안 요구
   if (loading) return null;
   if (error) return null;
   if (!availabilities) return null;
   if (availabilities.count === 0) return null;
 
-  return <MeetingAvailabilitiesContent availabilities={availabilities} />;
+  return (
+    <MeetingAvailabilitiesContent availabilities={availabilities} initialCount={initialCount} />
+  );
 };
 
 const MeetingAvailabilitiesContent = ({
   availabilities,
+  initialCount,
 }: {
   availabilities: MeetingAvailabilities;
+  initialCount: number;
 }) => {
-  const [selectedCount, setSelectedCount] = useState<number>(1);
+  const [selectedCount, setSelectedCount] = useState<number>(initialCount);
   const isUpperBound = selectedCount >= availabilities.count;
   const isLowerBound = selectedCount <= 1;
+
+  const calendarEvents = useMemo<EventInput[]>(() => {
+    const participantsTime = splitParticipantsTime(availabilities.participants);
+    console.log({ participantsTime });
+    const filteredTime = filterParticipantsTime(participantsTime, selectedCount);
+    console.log({ filteredTime });
+    const enabledTimes = mergeParticipantsTime(filteredTime);
+    console.log({ enabledTimes });
+    return enabledTimes.map((time) => ({
+      start: time.startAt,
+      end: time.endAt,
+      display: "block",
+      backgroundColor: "#ff7842",
+      borderColor: "#ff7842",
+      classNames: [styles.calendarEvent],
+    }));
+  }, [availabilities.participants, selectedCount]);
+
   return (
     <div className={styles.container}>
       <div className={styles.title}>
@@ -92,6 +128,20 @@ const MeetingAvailabilitiesContent = ({
           </div>
           <p>/ {availabilities.count}</p>
         </div>
+      </div>
+      <div className={styles.calendarContainer}>
+        <FullCalendar
+          plugins={[timeGridPlugin]}
+          initialView="timeGridWeek"
+          events={calendarEvents}
+          slotDuration="00:30:00"
+          slotMinTime="00:00:00"
+          slotMaxTime="24:00:00"
+          allDaySlot={false}
+          height="auto"
+          headerToolbar={false}
+          locale="ko"
+        />
       </div>
     </div>
   );

--- a/src/pages/meeting/detail/MeetingAvailabilities.tsx
+++ b/src/pages/meeting/detail/MeetingAvailabilities.tsx
@@ -32,41 +32,43 @@ export const MeetingAvailabilitiesContainer = ({ meetingId }: { meetingId: strin
         setLoading(false);
       });
   }, [meetingId]);
-  const initialCount = useMemo(() => {
-    if (!availabilities) return 1;
-    const participantsTime = splitParticipantsTime(availabilities.participants);
-    const maxCount = Math.max(...participantsTime.values(), 1);
-    return maxCount;
-  }, [availabilities]);
+
   // TODO: 각 케이스 디자인 시안 요구
   if (loading) return null;
   if (error) return null;
   if (!availabilities) return null;
   if (availabilities.count === 0) return null;
 
+  const participantsTime = splitParticipantsTime(availabilities.participants);
+  const initialCount = Math.max(...participantsTime.values(), 1);
+  const totalCount = availabilities.count;
+
   return (
-    <MeetingAvailabilitiesContent availabilities={availabilities} initialCount={initialCount} />
+    <MeetingAvailabilitiesContent
+      participantsTime={participantsTime}
+      initialCount={initialCount}
+      totalCount={totalCount}
+    />
   );
 };
 
 const MeetingAvailabilitiesContent = ({
-  availabilities,
+  participantsTime,
   initialCount,
+  totalCount,
 }: {
-  availabilities: MeetingAvailabilities;
+  /**Map<ISO format time(30분 단위), 가능한 참여자 수> */
+  participantsTime: Map<string, number>;
   initialCount: number;
+  totalCount: number;
 }) => {
   const [selectedCount, setSelectedCount] = useState<number>(initialCount);
-  const isUpperBound = selectedCount >= availabilities.count;
+  const isUpperBound = selectedCount >= totalCount;
   const isLowerBound = selectedCount <= 1;
 
   const calendarEvents = useMemo<EventInput[]>(() => {
-    const participantsTime = splitParticipantsTime(availabilities.participants);
-    console.log({ participantsTime });
     const filteredTime = filterParticipantsTime(participantsTime, selectedCount);
-    console.log({ filteredTime });
     const enabledTimes = mergeParticipantsTime(filteredTime);
-    console.log({ enabledTimes });
     return enabledTimes.map((time) => ({
       start: time.startAt,
       end: time.endAt,
@@ -75,7 +77,7 @@ const MeetingAvailabilitiesContent = ({
       borderColor: "#ff7842",
       classNames: [styles.calendarEvent],
     }));
-  }, [availabilities.participants, selectedCount]);
+  }, [participantsTime, selectedCount]);
 
   return (
     <div className={styles.container}>
@@ -90,11 +92,11 @@ const MeetingAvailabilitiesContent = ({
             name="count"
             className={styles.title__inputContainer__input}
             min={1}
-            max={availabilities.count}
+            max={totalCount}
             value={selectedCount}
             onChange={(e) => {
               const numValue = parseInt(e.target.value);
-              if (numValue > availabilities.count) {
+              if (numValue > totalCount) {
                 return;
               }
               setSelectedCount(numValue);
@@ -126,7 +128,7 @@ const MeetingAvailabilitiesContent = ({
               <BiChevronDown className={styles.title__inputContainer__iconContainer__icon} />
             </button>
           </div>
-          <p>/ {availabilities.count}</p>
+          <p>/ {totalCount}</p>
         </div>
       </div>
       <div className={styles.calendarContainer}>

--- a/src/pages/meeting/detail/MeetingDetailView.tsx
+++ b/src/pages/meeting/detail/MeetingDetailView.tsx
@@ -7,7 +7,7 @@ import MeetingStateCard from "./MeetingStateCard";
 import MeetingInfoCard from "./MeetingInfoCard";
 import type { MeetingDetail } from "@/apis/meeting/meetingTypes";
 import { scheduleStringFormatter } from "@/utils/dateFormatter";
-import { MeetingAvailabilitiesContainer } from "./Meetingavailabilities";
+import { MeetingAvailabilitiesContainer } from "./MeetingAvailabilities";
 
 const MeetingDetailView = ({ data }: { data: MeetingDetail }) => {
   const getMeetingTimeDisplay = () => {

--- a/src/pages/meeting/detail/MeetingDetailView.tsx
+++ b/src/pages/meeting/detail/MeetingDetailView.tsx
@@ -7,6 +7,7 @@ import MeetingStateCard from "./MeetingStateCard";
 import MeetingInfoCard from "./MeetingInfoCard";
 import type { MeetingDetail } from "@/apis/meeting/meetingTypes";
 import { scheduleStringFormatter } from "@/utils/dateFormatter";
+import { MeetingAvailabilitiesContainer } from "./Meetingavailabilities";
 
 const MeetingDetailView = ({ data }: { data: MeetingDetail }) => {
   const getMeetingTimeDisplay = () => {
@@ -55,6 +56,9 @@ const MeetingDetailView = ({ data }: { data: MeetingDetail }) => {
           data={data.participants}
         />
       </div>
+      {data.meetingStatus === "MATCH_FAILED" && (
+        <MeetingAvailabilitiesContainer meetingId={data.meetingId} />
+      )}
     </div>
   );
 };

--- a/src/utils/participantsTime.ts
+++ b/src/utils/participantsTime.ts
@@ -1,0 +1,85 @@
+import type { AvailabilityParticipant } from "@/apis/meeting/meetingTypes";
+import type { ParticipateObject } from "@/apis/participate/participateTypes";
+import { addMinutes, parseISO, isSameDay, formatISO } from "date-fns";
+
+/**
+ * 30분 단위로 참여자별 시간을 분리한 맵
+ * @return ISO format time(30분 단위): 가능한 참여자 수
+ */
+export const splitParticipantsTime = (participants: AvailabilityParticipant[]) => {
+  // 시간: 참여자 개수
+  const participantsTime = new Map<string, number>();
+  participants.forEach((participant) => {
+    participant.availabilities.forEach((availability) => {
+      const startTime = availability.startAt;
+      const endTime = availability.endAt;
+      const startTimeDate = parseISO(startTime);
+      const endTimeDate = parseISO(endTime);
+      let time = startTimeDate;
+      while (time < endTimeDate) {
+        if (participantsTime.has(time.toISOString())) {
+          participantsTime.set(time.toISOString(), participantsTime.get(time.toISOString())! + 1);
+        } else {
+          participantsTime.set(time.toISOString(), 1);
+        }
+        time = addMinutes(time, 30);
+      }
+    });
+  });
+  return participantsTime;
+};
+
+/**
+ * 개수를 만족하는 시간들만 필터링
+ * @return 30분단위 ISO format times
+ */
+export const filterParticipantsTime = (participantsTime: Map<string, number>, count: number) => {
+  return Array.from(participantsTime.entries())
+    .filter(([, value]) => value >= count)
+    .map(([key]) => key);
+};
+
+/**
+ * UI에 한번에 보이게 30분 단위 시간을 합침
+ * @param times 30분 단위 시간들
+ */
+export const mergeParticipantsTime = (times: string[]): ParticipateObject[] => {
+  if (times.length === 0) return [];
+
+  // 정렬
+  const sorted = times.map((time) => parseISO(time)).sort((a, b) => a.getTime() - b.getTime());
+
+  const result: ParticipateObject[] = [];
+  let start = sorted[0];
+  let end = sorted[0];
+
+  for (let i = 1; i < sorted.length; i++) {
+    const cur = sorted[i];
+    const expectedNext = addMinutes(end, 30);
+    const isConsecutive30Min = cur.getTime() === expectedNext.getTime();
+    const sameDay = isSameDay(cur, end);
+
+    if (sameDay && isConsecutive30Min) {
+      end = cur;
+      continue;
+    }
+
+    // flush current range
+    result.push({
+      startAt: formatISO(start),
+      endAt: formatISO(addMinutes(end, 30)),
+    });
+
+    // start new range
+    start = cur;
+    end = cur;
+  }
+
+  // flush last
+  result.push({
+    startAt: formatISO(start),
+    endAt: formatISO(addMinutes(end, 30)),
+  });
+
+  return result;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 작업 내용
  - 참가 시간 api 연동
  - 참가 캘린더 디자인 시안 구현
- 요구 사항
  - 미팅 실패시 참가 내역 확인 가능
  - 참가 내역은 number input의 value를 통해 value 이상의 참여자가 가능한 시간들을 캘린더에 표시
  - number input은 직접 타이핑 및 버튼으로 수정 가능
  - number input의 value는 1이상 최대 참여자수 이하만  
  - number input의 초기값은 참여가능한 최다 참여자
  - number input에서 불가능한 값 입력시 값이 안바뀜(음수, 전체 참여자 수 보다 큰 수 등)
- UX
  - 연속되는 시간 슬롯은 하나의 슬롯으로 합침
  - 초기 랜더링시, 캘린더 스크롤 위치를 최소 시간으로(단, 12시간 높이로 제한해 최소 시간은 무조건 오후12시 이상임)

### 스크린샷 (선택)
- 최대 가능 참여자수가 초기값이 되며, 스크롤이 min(오후 12시, 최소 참여시간)로 설정되는 모습
![화면 기록 2025-12-24 오후 5 16 39](https://github.com/user-attachments/assets/1ddb1115-8717-4efd-bbd0-aad05b01137e)

- input값에 따라 캘린더 활성화가 변화
![화면 기록 2025-12-24 오후 5 19 25](https://github.com/user-attachments/assets/57776c06-3dd7-4338-aa98-e56b995f208b)



## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

**지금 API 개발 시작 전!!!!!!!!!!**
- 다솔이 api 개발중이라 msw로 개발했음 백엔드 명세 바뀌면 터짐ㅋㅋ
