### PR TITLE
FIX: [KAN-225] 미팅 목록에서 스크롤시 미팅 상세로 바로 이동해버리는 오류 수정

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,8 +1,5 @@
 {
   "src/apis/meeting/meetingAPI.ts": {
-    "@typescript-eslint/no-unused-vars": {
-      "count": 1
-    },
     "no-case-declarations": {
       "count": 1
     }

--- a/src/apis/apiCall.ts
+++ b/src/apis/apiCall.ts
@@ -1,4 +1,4 @@
-import { UnauthorizedError } from "@/errors/errors";
+import { NetworkError, UnauthorizedError } from "@/errors/errors";
 import type { ApiResponse } from "./common/types";
 
 export const API_BASE = import.meta.env.VITE_API_BASE_URL;
@@ -68,8 +68,10 @@ export const apiCall = async <T>(
     .catch((e) => {
       localStorage.removeItem("access-token");
       localStorage.removeItem("refresh-token");
-      // TODO: 책임 이관 필요
-      window.location.href = "/";
+
+      if (e instanceof TypeError) {
+        throw new NetworkError();
+      }
       throw e;
     });
 };

--- a/src/apis/auth/authUtils.ts
+++ b/src/apis/auth/authUtils.ts
@@ -8,3 +8,7 @@ export const getResponseType = (code: number) => {
 export const isSuccess = (code: number) => {
   return code >= 200 && code < 300;
 };
+
+export const isFailure = (code: number) => {
+  return code >= 300;
+};

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -13,7 +13,7 @@
 html,
 body,
 #root {
-  height: 100%;
+  height: 100dvh;
 }
 
 body {

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -6,3 +6,12 @@ export class UnauthorizedError extends Error {
     this.message = "인증실패";
   }
 }
+
+export class NetworkError extends Error {
+  message: string;
+
+  constructor() {
+    super();
+    this.message = "네트워크 에러";
+  }
+}

--- a/src/pages/meeting/detail/MeetingStateCard.module.scss
+++ b/src/pages/meeting/detail/MeetingStateCard.module.scss
@@ -17,12 +17,12 @@
 }
 
 .complete {
-  color: $color-orange-10;
+  color: $color-orange-500;
   background-color: $color-cream-100;
 }
 
 .running {
-  color: $color-orange-100;
+  color: $color-orange-400;
   background-color: $color-cream-100;
 }
 

--- a/src/pages/meeting/detail/MeetingStateCard.tsx
+++ b/src/pages/meeting/detail/MeetingStateCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import styles from "./MeetingStateCard.module.scss";
 import RunningMatching from "@assets/runningMatching.svg?react";
 import CompletedMatching from "@assets/completedMatching.svg?react";
@@ -9,35 +9,44 @@ interface Props {
   data: MeetingDetail;
 }
 
-const MeetingStateCard = ({ data }: Props) => {
-  const [text, setText] = useState<string>();
-  const [icon, setIcon] = useState<ReactNode>();
-  const [style, setStyle] = useState<string>();
+type MeetingStatus = MeetingDetail["meetingStatus"];
 
-  const stateResolver = () => {
-    if (data.meetingStatus === "MATCHING") {
-      setText("매칭 중");
-      setIcon(<RunningMatching className={styles.running} />);
-      setStyle(styles.running);
-    } else if (data.meetingStatus === "MATCH_FAILED") {
-      setText("매칭 실패");
-      setIcon(<FailedMatching className={styles.fail} />);
-      setStyle(styles.fail);
-    } else if (data.meetingStatus === "BEFORE") {
-      setText("매칭 완료");
-      setIcon(<CompletedMatching className={styles.complete} />);
-      setStyle(styles.complete);
+const UI_BY_STATUS: Partial<
+  Record<
+    MeetingStatus,
+    {
+      text: string;
+      className: string;
+      icon: ReactNode;
     }
-  };
+  >
+> = {
+  MATCHING: {
+    text: "매칭 중",
+    className: styles.running,
+    icon: <RunningMatching className={styles.running} />,
+  },
+  MATCH_FAILED: {
+    text: "매칭 실패",
+    className: styles.fail,
+    icon: <FailedMatching className={styles.fail} />,
+  },
+  BEFORE: {
+    text: "매칭 완료",
+    className: styles.complete,
+    icon: <CompletedMatching className={styles.complete} />,
+  },
+};
 
-  useEffect(() => {
-    stateResolver();
-  }, [data]);
+const MeetingStateCard = ({ data }: Props) => {
+  const ui = UI_BY_STATUS[data.meetingStatus];
+
+  if (!ui) return null;
 
   return (
-    <div className={`${styles.meetingStateCard} ${style}`}>
-      {icon}
-      {text}
+    <div className={`${styles.meetingStateCard} ${ui.className}`}>
+      {ui.icon}
+      {ui.text}
     </div>
   );
 };

--- a/src/pages/meeting/list/MeetingIncompleteSection.tsx
+++ b/src/pages/meeting/list/MeetingIncompleteSection.tsx
@@ -21,7 +21,7 @@ const MeetingIncompleteSection = ({ meetingList }: { meetingList: Meeting[] }) =
           const diff = priority[a.meetingStatus] - priority[b.meetingStatus];
           if (diff !== 0) return diff;
 
-          return isBefore(a.deadline, b.deadline) ? -1 : 1;
+          return isBefore(a.deadline as string, b.deadline as string) ? -1 : 1;
         })
     );
   }, [meetingList]);

--- a/src/pages/meeting/list/MeetingItemCard.module.scss
+++ b/src/pages/meeting/list/MeetingItemCard.module.scss
@@ -3,6 +3,11 @@
   width: 100%;
   display: flex;
 
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+
   .swipeTrack {
     width: 100%;
     will-change: transform;

--- a/src/pages/meeting/list/MeetingItemCard.tsx
+++ b/src/pages/meeting/list/MeetingItemCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useMemo } from "react";
 import styles from "./MeetingItemCard.module.scss";
 import { useNavigate } from "react-router-dom";
 import {
@@ -8,9 +8,8 @@ import {
 import type { Meeting } from "@/apis/meeting/meetingTypes";
 import { deleteMeeting } from "@/apis/meeting/meetingAPI";
 
-import { useMouseEvent } from "../create/hooks/useHandleMouseEvent";
-
 import trashCan from "@assets/trashCan.svg";
+import { useMeetingStore } from "@/store/meetingStore";
 
 interface Props {
   data: Meeting;
@@ -18,6 +17,7 @@ interface Props {
 
 const DelBtnWidth = 72;
 const OPEN_THRESHOLD = 0.5;
+const MOVE_THRESHOLD = 6;
 
 const MeetingItemCard = ({ data }: Props) => {
   const currentStatus: string = data.meetingStatus;
@@ -25,10 +25,6 @@ const MeetingItemCard = ({ data }: Props) => {
   const isMatchFailed: boolean = currentStatus === "MATCH_FAILED";
 
   const navigate = useNavigate();
-
-  const [meetingDetail, setMeetingDetail] = useState<string>("");
-  const [cardStyle, setCardStyle] = useState<string>();
-  const [textStyle, setTextStyle] = useState<string>();
 
   const [open, setOpen] = useState<boolean>(false);
   const [dragging, setDragging] = useState<boolean>(false); //스와이프가 진행중인지 여부
@@ -39,7 +35,9 @@ const MeetingItemCard = ({ data }: Props) => {
   const movedRef = useRef(false); //드래그가 발생했는지
   const targetRef = useRef<HTMLDivElement | null>(null);
 
-  useMouseEvent({ open, setOpen, targetRef });
+  const fetchMeetings = useMeetingStore((state) => state.fetchMeetings);
+
+  // useMouseEvent({ open, setOpen, targetRef });
 
   const handleClick = () => {
     navigate("detail", {
@@ -49,36 +47,35 @@ const MeetingItemCard = ({ data }: Props) => {
     });
   };
 
-  //형코드
-  const cardInfoResolver = () => {
-    if (currentStatus === "MATCHING") {
-      setMeetingDetail(`${incompletedMeetingDateFormatter(data.deadline)} 종료`);
-      setCardStyle(styles.incomplete);
-      setTextStyle(styles.incompleteText);
-    } else if (currentStatus === "MATCH_FAILED") {
-      setMeetingDetail("매칭 실패");
-      setCardStyle(styles.fail);
-      setTextStyle(styles.failText);
-    } else {
-      setMeetingDetail(
-        `${completedMeetingDateFormatter(data.confirmedTime, data.durationMinutes)}`
-      );
-      setCardStyle(styles.success);
-    }
-  };
+  const clamp = (v: number, min: number, max: number) => Math.min(max, Math.max(min, v));
 
-  useEffect(() => {
-    cardInfoResolver();
-  }, [data]);
-  //형코드
+  const view = useMemo(() => {
+    if (currentStatus === "MATCHING") {
+      return {
+        meetingDetail: `${incompletedMeetingDateFormatter(data.deadline)} 종료`,
+        cardStyle: styles.incomplete,
+        textStyle: styles.incompleteText,
+      };
+    }
+    if (currentStatus === "MATCH_FAILED") {
+      return {
+        meetingDetail: "매칭 실패",
+        cardStyle: styles.fail,
+        textStyle: styles.failText,
+      };
+    }
+    return {
+      meetingDetail: `${completedMeetingDateFormatter(data.confirmedTime, data.durationMinutes)}`,
+      cardStyle: styles.success,
+      textStyle: undefined,
+    };
+  }, [currentStatus, data.deadline, data.confirmedTime, data.durationMinutes]);
+
   useEffect(() => {
     setTx(open ? -DelBtnWidth : 0);
   }, [open]);
-  //범위 제한 유틸함수
-  const clamp = (v: number, min: number, max: number) => Math.min(max, Math.max(min, v));
-  //MeetingItemCard에 클릭했을 때의 동작
+
   const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (!isMatchFailed) return; // 매칭중일 때만 슬라이드 허용
     setDragging(true);
     movedRef.current = false;
 
@@ -88,34 +85,35 @@ const MeetingItemCard = ({ data }: Props) => {
     // 드래그 캡처, 드래그가 시작된 이후, 커서가 요소 밖으로 나가더라도 pointermove/pointer up 이벤트를 계속 이요소가 받게 하려는 기능
     (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
   };
-  //드래그 했을 때 동작
+
   const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
     if (!dragging) return;
 
     const dx = e.clientX - startXRef.current;
     const dy = e.clientY - startYRef.current;
 
-    // 수평 우세 시에만 슬라이드
-    if (Math.abs(dx) < 8 && Math.abs(dy) < 8) return;
-    if (Math.abs(dx) < Math.abs(dy)) return;
+    if (Math.abs(dx) > MOVE_THRESHOLD || Math.abs(dy) > MOVE_THRESHOLD) {
+      movedRef.current = true;
+    } else {
+      return;
+    }
 
-    movedRef.current = true;
+    if (Math.abs(dx) < Math.abs(dy)) return; // 커서의 수평이동량이 더 많을 경우에만 슬라이드
 
     // 왼쪽 스와이프만 허용(컨텐츠를 왼쪽으로 보내 버튼 노출)
     const next = clamp(dx + (open ? -DelBtnWidth : 0), -DelBtnWidth, 0);
-    setTx(next);
+    if (isMatchFailed) setTx(next);
 
     // 스와이프 중 화면이 스크롤 되는것을 막아준다.
     e.preventDefault();
   };
-  //드래그 종료
+
   const onPointerUp = () => {
     if (!dragging) return;
     setDragging(false);
 
     const opened = Math.abs(tx) >= DelBtnWidth * OPEN_THRESHOLD;
     setOpen(opened);
-    setTx(opened ? -DelBtnWidth : 0);
 
     if (!movedRef.current && !opened) {
       handleClick();
@@ -126,9 +124,11 @@ const MeetingItemCard = ({ data }: Props) => {
 
   const handleDeleteBtn = async () => {
     try {
-      const res = await deleteMeeting(data.meetingId);
+      if (await deleteMeeting(data.meetingId)) {
+        alert("삭제에 성공했습니다!");
+        fetchMeetings();
+      }
       navigate("/meeting");
-      console.log(res);
     } catch (e) {
       console.error(e);
     }
@@ -143,11 +143,6 @@ const MeetingItemCard = ({ data }: Props) => {
       onPointerUp={onPointerUp}
       onPointerCancel={onPointerUp}
       className={styles.meetingItemCardWithDelete}
-      onClick={() => {
-        if (!isMatchFailed) {
-          handleClick();
-        }
-      }}
     >
       <div
         className={styles.swipeTrack}
@@ -157,16 +152,16 @@ const MeetingItemCard = ({ data }: Props) => {
         }}
       >
         <div className={styles.meetingItemCard}>
-          <div className={`${styles.meetingItemCard__leftEdge} ${cardStyle}`}></div>
+          <div className={`${styles.meetingItemCard__leftEdge} ${view.cardStyle}`}></div>
           <div className={styles.meetingItemCard__dataArea}>
             <div className={styles.meetingItemCard__dataArea__meetingInfo}>
               <div className={styles.meetingItemCard__dataArea__meetingInfo__meetingName}>
                 {data.title}
               </div>
               <div
-                className={`${styles.meetingItemCard__dataArea__meetingInfo__meetingDetail} ${textStyle}`}
+                className={`${styles.meetingItemCard__dataArea__meetingInfo__meetingDetail} ${view.textStyle}`}
               >
-                {meetingDetail}
+                {view.meetingDetail}
               </div>
             </div>
           </div>

--- a/src/pages/schedule/weekly_schedule/weeklyCalendarConfig.ts
+++ b/src/pages/schedule/weekly_schedule/weeklyCalendarConfig.ts
@@ -12,7 +12,7 @@ export const calendarConfig = {
 
   step: 30, // 각 시간 슬롯 간격 (분 단위)
   timeslots: 2, // 한 시간당 몇 개의 슬롯
-  longPressThreshold: 750,
+  longPressThreshold: 500,
 
   formats: {
     timeGutterFormat: (date: Date) => {


### PR DESCRIPTION
## #️⃣연관된 이슈

https://pds2023.atlassian.net/browse/KAN-225

## 📝작업 내용

* 미팅 목록에서 스크롤을 위해 터치를 했을때 바로 터치관련 이벤트핸들러가 동작해서 스크롤의 기회를 잃어버리는 오류를 수정
* 미팅 삭제가 바로 안되는 오류 수정
* 미팅 삭제시 새로 업데이트된 미팅 목록이 바로 반영

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
