### PR TITLE
FIX: [KAN-229] 미팅 참가페이지에서 일정 선택시 여러 날에 걸쳐있는 경우 시작부터 끝까지 전체가 선택되는 오류 수정

### DIFF
--- a/src/pages/participate/Participate_timetable/Participate_timetabe.scss
+++ b/src/pages/participate/Participate_timetable/Participate_timetabe.scss
@@ -255,3 +255,18 @@
     font-size: 60%;
   }
 }
+
+// 1. 기본 선택 하이라이트 숨기기 (가장 중요!)
+// 이걸 숨겨야 통짜 사각형이 안 보이고 우리가 만든 조각들이 보임
+.fc-highlight {
+  display: none !important;
+  opacity: 0 !important;
+}
+
+// 2. 우리가 만든 드래그 미리보기 스타일
+.fc-drag-preview {
+  background-color: rgba(55, 136, 216, 0.5) !important; // FullCalendar 기본색과 유사한 반투명 파랑
+  border: none !important;
+  pointer-events: none; // 마우스 이벤트 방해 금지
+  z-index: 1; // Grid 위, 기존 이벤트 아래 적절히 배치
+}

--- a/src/pages/participate/Participate_timetable/Participate_timetabe.scss
+++ b/src/pages/participate/Participate_timetable/Participate_timetabe.scss
@@ -107,6 +107,12 @@
       }
 
       > p {
+        display: flex;
+        flex-direction: row;
+        justify-content: start;
+        align-items: center;
+        gap: 10px;
+
         font-family: Pretendard;
         font-weight: 500;
         font-style: Medium;
@@ -114,8 +120,17 @@
         line-height: 100%;
         letter-spacing: 0%;
         color: #616161;
-        > span {
+        > .star {
           color: #ff6200;
+        }
+
+        > .resetBtn {
+          background-color: $color-orange-400;
+          border-radius: 15px;
+          padding: 5px;
+
+          color: white;
+          font-size: smaller;
         }
       }
     }

--- a/src/pages/participate/Participate_timetable/Participate_timetable_ctn.tsx
+++ b/src/pages/participate/Participate_timetable/Participate_timetable_ctn.tsx
@@ -6,11 +6,7 @@ import CountDown from "@/components/CountDown/CountDown";
 
 import LeftChevron from "@/assets/LeftChevron.svg";
 
-import type {
-  ParticipateResponse,
-  UserScheduleData,
-  MeetingInfoData,
-} from "@/apis/participate/participateTypes";
+import type { UserScheduleData, MeetingInfoData } from "@/apis/participate/participateTypes";
 
 import "./Participate_timetabe.scss";
 
@@ -34,8 +30,7 @@ const Participate_timetable_ctn = () => {
 
   const [meetingData, setMeetingData] = useState<MeetingInfoData | null>(null); //참가페이지에 해당하는 미팅 데이터
   const [scheduleData, setScheduleData] = useState<UserScheduleData[]>([]); //사용자의 캘린더 데이터
-  const [previousAvailTime, setPreviousAvailTime] = useState<ParticipateResponse | null>(null); //이전에 선택했던 시간 데이터 대안 시간 투표를 위한 데이터
-
+  const [previousAvailTime, setPreviousAvailTime] = useState<ParticipateObject[]>([]); //이전에 선택했던 시간 데이터 대안 시간 투표를 위한 데이터
   //이 친구는 선택된 시간 데이터들(startAt,endAt)데이터들의 배열임
   const [selectedTimes, setSelectedTimes] = useState<ParticipateObject[]>([]); //  수정됨: 선택된 시간 저장용 state
 
@@ -52,6 +47,12 @@ const Participate_timetable_ctn = () => {
   const handleSetNickname = (e) => {
     setNickname(e.target.value);
   }; //나중에 backend에 post로 보낼예정..
+
+  const resetToInitialSelection = () => {
+    if (previousAvailTime) {
+      setSelectedTimes(previousAvailTime);
+    }
+  };
 
   const handleSubmit = useHandleSubmitData(meetingId, pageNum as string, finalPostData);
 
@@ -83,7 +84,13 @@ const Participate_timetable_ctn = () => {
 
         <div className="timetable">
           <p>
-            참여 가능 시간<span>*</span>
+            <span>
+              <span>참여 가능 시간</span>
+              <span className="star"> *</span>
+            </span>
+            <button className="resetBtn" onClick={() => resetToInitialSelection()}>
+              초기화
+            </button>
           </p>
           <div
             className="timetable_ctn"

--- a/src/pages/participate/Participate_timetable/TimetableHooks/ParticipateCtn/useHandleSubmit.ts
+++ b/src/pages/participate/Participate_timetable/TimetableHooks/ParticipateCtn/useHandleSubmit.ts
@@ -22,15 +22,16 @@ export const useHandleSubmitData = (
     const isModify = pageNum === "3";
 
     try {
-      const result = isModify
-        ? await updateAvailability(meetingId, {
-            selectedTimes: finalPostData.selectedTimes,
-          })
-        : await submitAvailability(meetingId, finalPostData);
-
-      console.log(result);
+      if (isModify) {
+        await updateAvailability(meetingId, {
+          selectedTimes: finalPostData.selectedTimes,
+        });
+      } else {
+        await submitAvailability(meetingId, finalPostData);
+      }
 
       if (isModify) {
+        alert("수정이 완료되었습니다!");
         navigate("/meeting/detail", { state: { meetingId } });
       } else {
         navigate("/schedule");

--- a/src/pages/participate/Participate_timetable/TimetableHooks/Timetable/useTimetableSelection.ts
+++ b/src/pages/participate/Participate_timetable/TimetableHooks/Timetable/useTimetableSelection.ts
@@ -84,8 +84,6 @@ function keysToIntervals(set: Set<string>): ParticipateObject[] {
   }
   out.push({ startAt: new Date(curStart).toISOString(), endAt: new Date(curEnd).toISOString() });
 
-  console.log(out);
-
   return out;
 }
 
@@ -122,6 +120,7 @@ export function splitRectSelection(start: Date, end: Date): Array<{ start: Date;
 
     segments.push({ start: segStart, end: segEnd });
   }
+  console.log(segments);
 
   return segments;
 }

--- a/src/pages/participate/Participate_timetable/TimetableHooks/Timetable/useTimetableSelection.ts
+++ b/src/pages/participate/Participate_timetable/TimetableHooks/Timetable/useTimetableSelection.ts
@@ -1,12 +1,31 @@
-import type React from "react";
 import type { ParticipateObject } from "@/apis/participate/participateTypes";
-import { addMinutes } from "date-fns";
-import { snap30, keyOf } from "@/utils/dateUtil"; // ✅ 네 util 사용 (경로만 맞춰줘)
+import {
+  addDays,
+  addMinutes,
+  differenceInCalendarDays,
+  startOfDay,
+  subMilliseconds,
+} from "date-fns";
+import { snap30, keyOf } from "@/utils/dateUtil";
+import { useCallback, useRef, useState, type Dispatch, type SetStateAction } from "react";
+
+/**드래그 영역을 분해할 때 분해된 요소의 단위 */
+interface Segment {
+  id: string;
+  start: Date;
+  end: Date;
+  display: string;
+  className: string;
+}
 
 const MIN30 = 30; // minutes
 
-// 30분 슬롯 단위로 [start,end) 를 펼쳐 "slotKey" Set으로 토글
-function toggleRangeKeys(prev: ParticipateObject[], start: Date, end: Date): ParticipateObject[] {
+// 30분 슬롯 단위로 [start,end] 를 펼쳐 "slotKey" Set으로 토글
+export function toggleRangeKeys(
+  prev: ParticipateObject[],
+  start: Date,
+  end: Date
+): ParticipateObject[] {
   // 1) 기존 intervals -> slotKey Set
   const set = new Set<string>();
   for (const it of prev) {
@@ -34,7 +53,7 @@ function toggleRangeKeys(prev: ParticipateObject[], start: Date, end: Date): Par
   return keysToIntervals(set);
 }
 
-// slotKey("s|e")들을 정렬해서 연속 구간으로 압축
+/** slotKey("s|e")들을 정렬해서 연속 구간으로 압축 */
 function keysToIntervals(set: Set<string>): ParticipateObject[] {
   const slots = Array.from(set)
     .map((k) => {
@@ -65,24 +84,111 @@ function keysToIntervals(set: Set<string>): ParticipateObject[] {
   }
   out.push({ startAt: new Date(curStart).toISOString(), endAt: new Date(curEnd).toISOString() });
 
+  console.log(out);
+
   return out;
 }
 
+/** 연속 구간(start~end)을 "날짜별 직사각형" 구간들로 분해하는 메서드 */
+export function splitRectSelection(start: Date, end: Date): Array<{ start: Date; end: Date }> {
+  // end는 exclusive라서 end-1ms 기준으로 마지막 포함 날짜 계산
+  const lastIncluded = subMilliseconds(end, 1);
+
+  const fromDay = startOfDay(start);
+  const toDay = startOfDay(lastIncluded);
+
+  const toMin = (d: Date) => d.getHours() * 60 + d.getMinutes();
+
+  // end가 다음날 00:00으로 들어오는 경우(=24:00 선택) 보정
+  const normalizeEndMin = () => {
+    const m = toMin(end);
+    if (m === 0 && end > start) return 1440; // 24:00 취급
+    return m;
+  };
+
+  const sMin = toMin(start);
+  const eMin = normalizeEndMin();
+  const minMin = Math.min(sMin, eMin);
+  const maxMin = Math.max(sMin, eMin);
+
+  const segments: Array<{ start: Date; end: Date }> = [];
+
+  for (let day = fromDay; differenceInCalendarDays(toDay, day) >= 0; day = addDays(day, 1)) {
+    const segStart = addMinutes(startOfDay(day), minMin);
+    const segEnd =
+      maxMin === 1440
+        ? addDays(startOfDay(day), 1) // 24:00이면 다음날 00:00
+        : addMinutes(startOfDay(day), maxMin);
+
+    segments.push({ start: segStart, end: segEnd });
+  }
+
+  return segments;
+}
+
 export const useTimetableSelection = (
-  setSelectedTimes: React.Dispatch<React.SetStateAction<ParticipateObject[]>>
+  setSelectedTimes: Dispatch<SetStateAction<ParticipateObject[]>>
 ) => {
-  // ✅ 드래그 토글
+  const [dragPreviewEvents, setDragPreviewEvents] = useState<Segment[]>([]);
+  const lastDragInfo = useRef<{ start: number; end: number } | null>(null); // 드래그 중 불필요한 재연산을 막기 위해 마지막 계산 범위를 기억
+
+  /** 드래그 중 실시간 프리뷰 계산하는 메서드 (selectAllow 활용) */
+  const handleSelectAllow = useCallback((selectInfo) => {
+    // 1. 현재 드래그 범위가 이전과 같으면 업데이트 건너뜀 (성능 최적화)
+    const currentStart = selectInfo.start.getTime();
+    const currentEnd = selectInfo.end.getTime();
+
+    if (
+      lastDragInfo.current &&
+      lastDragInfo.current.start === currentStart &&
+      lastDragInfo.current.end === currentEnd
+    ) {
+      return true;
+    }
+
+    // 2. 변경되었다면 저장
+    lastDragInfo.current = { start: currentStart, end: currentEnd };
+
+    // 3. 로직을 통해 조각난 구간 계산
+    const segments = splitRectSelection(selectInfo.start, selectInfo.end);
+
+    // 4. 미리보기 이벤트 생성
+    const previews = segments.map((seg, idx) => ({
+      id: `preview-${idx}`,
+      start: seg.start,
+      end: seg.end,
+      display: "background", // 혹은 'preview' (CSS 커스텀용)
+      className: "fc-drag-preview",
+    }));
+
+    setDragPreviewEvents(previews);
+    return true; // 선택 허용
+  }, []);
+
+  /** 드래그 토글 */
   const handleSelect = (info) => {
-    setSelectedTimes((prev) => toggleRangeKeys(prev, info.start, info.end));
+    // setSelectedTimes((prev) => toggleRangeKeys(prev, info.start, info.end));
+    const segments = splitRectSelection(info.start, info.end);
+
+    setSelectedTimes((prev) =>
+      segments.reduce((acc, seg) => toggleRangeKeys(acc, seg.start, seg.end), prev)
+    );
     info.view?.calendar?.unselect?.();
   };
 
-  // ✅ 클릭(한 칸) 토글: dateClick은 클릭한 "시각"이 들어옴
+  /** 클릭(한 칸) 토글: dateClick은 클릭한 시각이 들어옴 */
   const handleDateClick = (info) => {
     const start = snap30(info.date);
     const end = addMinutes(start, MIN30);
     setSelectedTimes((prev) => toggleRangeKeys(prev, start, end));
   };
 
-  return { handleSelect, handleDateClick };
+  return {
+    dragPreviewEvents,
+    setDragPreviewEvents,
+    lastDragInfo,
+    handleSelectAllow,
+    handleSelect,
+    handleDateClick,
+  };
 };

--- a/src/pages/participate/Participate_timetable/TimetableHooks/Timetable/useTimetableSelection.ts
+++ b/src/pages/participate/Participate_timetable/TimetableHooks/Timetable/useTimetableSelection.ts
@@ -120,7 +120,6 @@ export function splitRectSelection(start: Date, end: Date): Array<{ start: Date;
 
     segments.push({ start: segStart, end: segEnd });
   }
-  console.log(segments);
 
   return segments;
 }

--- a/src/utils/eventTransform.ts
+++ b/src/utils/eventTransform.ts
@@ -17,15 +17,15 @@ interface SelectedEvent {
   classNames: string[];
   extendedProps: Record<string, boolean>;
 }
-//사용자의 구글캘린더 일정 정보 불러와 데이터 재설정
-export const toBusyEvents = (scheduleData: UserScheduleData[]): BusyEvent[] =>
+/** 사용자의 구글캘린더 일정 정보 불러와 데이터 재설정 */
+export const parseUserCalendarEvents = (scheduleData: UserScheduleData[]): BusyEvent[] =>
   scheduleData.map((ev) => ({
     start: parseISO(ev.startAt),
     end: parseISO(ev.endAt),
     display: "background",
     classNames: ["busy-block"],
     extendedProps: { isBusy: false },
-  })); //결과는 toBusyEvents는 이러한 데이터 형식가진 배열
+  }));
 
 //색 6개 중에 번갈아 가면서 설정
 


### PR DESCRIPTION
## #️⃣연관된 이슈

https://pds2023.atlassian.net/browse/KAN-229

## 📝작업 내용

- 이전까지는 여러 요일에 걸쳐서 일정을 지정하는 경우, 시작시간부터
  끝시간까지 모든 범위가 설정되었음
- 현재 수정을 통해 마우스 커서가 클릭 후 이동한 범위에 대해서만 일정이
  선택되도록 수정
- 이를 위해서 useTimetableSelection 훅을 수정
   - splitRectSelection은 연속 구간을 시간대가 같은 직사각형들로
     쪼개주는 순수함수임
   - handleSelectAllow는 preview(클릭을 놓기전에 미리 보여지는
     선택부분)를 계산해서 보여주기위한 함수

### 스크린샷 (선택)

https://github.com/user-attachments/assets/f47fe015-8e68-4b99-b768-f241bf20b9d5


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
