### PR TITLE
FIX : 미팅 참가 후 alert 팝업 추가

### DIFF
--- a/src/pages/participate/Participate_timetable/TimetableHooks/ParticipateCtn/useHandleSubmit.ts
+++ b/src/pages/participate/Participate_timetable/TimetableHooks/ParticipateCtn/useHandleSubmit.ts
@@ -34,6 +34,7 @@ export const useHandleSubmitData = (
         alert("수정이 완료되었습니다!");
         navigate("/meeting/detail", { state: { meetingId } });
       } else {
+        alert("미팅 참가가 완료되었습니다!");
         navigate("/schedule");
       }
     } catch (e) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

* 미팅 참가 후 바로 Schedule 페이지로 아무 알림이 없이 이동하는 것 같아서 성공 alert 창을 팝업 후 이동하도록 수정하였습니다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
